### PR TITLE
[FEAT] 웹소켓 초기 세팅

### DIFF
--- a/src/main/java/com/project/catxi/chat/config/StompEventListener.java
+++ b/src/main/java/com/project/catxi/chat/config/StompEventListener.java
@@ -1,0 +1,33 @@
+package com.project.catxi.chat.config;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Component
+public class StompEventListener {
+	private final Set<String> sessions = ConcurrentHashMap.newKeySet();
+
+	@EventListener
+	public void connectHandle(SessionConnectEvent event){
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		sessions.add(accessor.getSessionId());
+		System.out.println("connect session Id" + accessor.getSessionId());
+		System.out.println("total session : "+sessions.size());
+	}
+
+	@EventListener
+	public void disconnectHandle(SessionDisconnectEvent event){
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		sessions.remove(accessor.getSessionId());
+		System.out.println("disconnect session Id" + accessor.getSessionId());
+		System.out.println("total session : "+sessions.size());
+	}
+}
+
+

--- a/src/main/java/com/project/catxi/chat/config/StompHandler.java
+++ b/src/main/java/com/project/catxi/chat/config/StompHandler.java
@@ -1,0 +1,65 @@
+
+package com.project.catxi.chat.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+/*@Component
+public class StompHandler implements ChannelInterceptor {
+
+
+	@Value("${jwt.secretKey}")
+	private String secretKey;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		final StompHeaderAccessor accessor=StompHeaderAccessor.wrap(message);
+
+		if(StompCommand.CONNECT==accessor.getCommand()){
+			System.out.println("connect 요청시 토큰 유효성 검증");
+			String bearerToken=accessor.getFirstNativeHeader("Authorization");
+			String token=bearerToken.substring(7);
+			//토큰 검증
+			Jwts.parserBuilder()
+				.setSigningKey(secretKey)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+			System.out.println("토큰 검증 완료");
+		}
+		if (StompCommand.SUBSCRIBE == accessor.getCommand()) {
+			System.out.println("subscribe 검증");
+			String bearerToken=accessor.getFirstNativeHeader("Authorization");
+			String token=bearerToken.substring(7);
+			Claims claims=Jwts.parserBuilder()
+				.setSigningKey(secretKey)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+			String email=claims.getSubject();
+			String roomId=accessor.getDestination().split("/")[2];
+			if(!chatService.isRoomParticipant(email,Long.parseLong(roomId))){
+				throw new AuthenticationServiceException("해당 room에 권한이 없습니다");
+			}
+		}
+
+
+		return message;
+	}
+
+
+
+}*/
+
+@Component
+public class StompHandler implements ChannelInterceptor {
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		return message;
+	}
+}

--- a/src/main/java/com/project/catxi/chat/config/StompWebSocketConfig.java
+++ b/src/main/java/com/project/catxi/chat/config/StompWebSocketConfig.java
@@ -1,0 +1,46 @@
+package com.project.catxi.chat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+
+	private final StompHandler stompHandler;
+
+	public StompWebSocketConfig(StompHandler stompHandler) {
+		this.stompHandler = stompHandler;
+	}
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/connect")
+			.setAllowedOrigins("http://localhost:3000")
+			//ws://가 아닌 http:// 엔드포인트를 사용할 수 있게 해주는 socketJs 라이브러리를 통한 요청을 허용하는 설정
+			.withSockJS();
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		//  /publish/1 형태로 메시지 발행해야 함을 설정
+		// /publish 로 시작하는 url 패턴으로 메시지가 발행되면 @Controller 객체의 @MessageMapping 메서드로 라우팅
+		registry.setApplicationDestinationPrefixes("/publish");
+
+		//  /topic/1 형태로 메시지 수신해야 함을 설정
+		// /topic 로 시작하는 url 패턴으로 메시지가 발행되면 @Controller 객체의 @MessageMapping 메서드로 라우팅
+		registry.enableSimpleBroker("/topic");
+
+	}
+
+	//웹소켓 요청(connect, subscribe, disconnect )등의 요청시에는 http header 등 http 메시지를 넣어올 수 있고 이를 interceptor 를 통해 가로채 토큰등을 검증할 수 있음.
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(stompHandler);
+	}
+}

--- a/src/main/java/com/project/catxi/chat/controller/StompController.java
+++ b/src/main/java/com/project/catxi/chat/controller/StompController.java
@@ -1,0 +1,28 @@
+package com.project.catxi.chat.controller;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.catxi.chat.dto.ChatMessageReqDto;
+
+@Controller
+public class StompController {
+
+	private final SimpMessageSendingOperations messageTemplate;
+
+	public StompController(SimpMessageSendingOperations messageTemplate) {
+		this.messageTemplate = messageTemplate;
+	}
+
+	@MessageMapping("/{roomId}")
+	public void sendMessage(@DestinationVariable Long roomId, ChatMessageReqDto chatMessageReqDto) {
+		System.out.println(chatMessageReqDto.getMessage());
+		//해당 roomId에 메시지를 방행하여 구독중인 클라이언트에게 메시지 전송
+		messageTemplate.convertAndSend("/topic/" + roomId, chatMessageReqDto);
+	}
+}

--- a/src/main/java/com/project/catxi/chat/dto/ChatMessageReqDto.java
+++ b/src/main/java/com/project/catxi/chat/dto/ChatMessageReqDto.java
@@ -1,0 +1,13 @@
+package com.project.catxi.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageReqDto {
+	private String message;
+	private String name;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용
- 채팅 기능 개발을 위해 STOMP 웹소켓 기본 구조를 먼저 세팅했습니다.
- 로그인(OAuth2 + JWT) 기능이 아직 미완성이라, 토큰 검증 로직은 주석 처리하고 임시 핸들러만 활성화했습니다.
- 로그인 기능 완료 후 `StompHandler` 의 주석을 해제하면 바로 보안이 적용됩니다.
- /connect 엔드포인트의 WebSocket CORS 허용 상태입니다.

**테스트 방법**
(STOMP 웹소켓은 프론트 부분이 구현이 되지 않는다면 테스트하기 어렵습니다.)
1. 프론트에서 SockJS 로 /connect 접속
2. /topic/{roomId} 구독 -> /publish/{roomId} 로 메시지 전송
3. 서버 콘솔에 메시지 내용 & 세션 로그 출력 확인
4. 브라우저 콘솔에 수신 메시지 확인
