### PR TITLE
[FEAT] 채팅 메시지 저장 로직 추가

### DIFF
--- a/src/main/java/com/project/catxi/chat/controller/ChatController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatController.java
@@ -1,19 +1,22 @@
 package com.project.catxi.chat.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.catxi.chat.service.ChatMessageService;
+import com.project.catxi.common.api.ApiResponse;
+import com.project.catxi.common.api.CommonPageResponse;
 
 @RestController
 @RequestMapping("/chat")
-public class ChatMessageController {
+public class ChatController {
 
 	private final ChatMessageService chatMessageService;
 
-	public ChatMessageController(ChatMessageService chatMessageService) {
+	public ChatController(ChatMessageService chatMessageService) {
 		this.chatMessageService = chatMessageService;
 	}
-
 
 }

--- a/src/main/java/com/project/catxi/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatMessageController.java
@@ -1,0 +1,19 @@
+package com.project.catxi.chat.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.catxi.chat.service.ChatMessageService;
+
+@RestController
+@RequestMapping("/chat")
+public class ChatMessageController {
+
+	private final ChatMessageService chatMessageService;
+
+	public ChatMessageController(ChatMessageService chatMessageService) {
+		this.chatMessageService = chatMessageService;
+	}
+
+
+}

--- a/src/main/java/com/project/catxi/chat/domain/ChatMessage.java
+++ b/src/main/java/com/project/catxi/chat/domain/ChatMessage.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Builder
 public class ChatMessage extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/com/project/catxi/chat/dto/ChatMessageRes.java
+++ b/src/main/java/com/project/catxi/chat/dto/ChatMessageRes.java
@@ -1,0 +1,12 @@
+package com.project.catxi.chat.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageRes(
+	Long   messageId,
+	Long   roomId,
+	Long   senderId,
+	String senderName,
+	String content,
+	LocalDateTime sentAt
+) { }

--- a/src/main/java/com/project/catxi/chat/dto/ChatMessageSendReq.java
+++ b/src/main/java/com/project/catxi/chat/dto/ChatMessageSendReq.java
@@ -1,0 +1,7 @@
+package com.project.catxi.chat.dto;
+
+public record ChatMessageSendReq(
+	Long   roomId,
+	Long   senderId,      // Member PK (or 이메일·닉네임으로 변경 가능)
+	String message
+) { }

--- a/src/main/java/com/project/catxi/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,10 @@
+package com.project.catxi.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.project.catxi.chat.domain.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+}
+

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.project.catxi.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.project.catxi.chat.domain.ChatRoom;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {}

--- a/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
@@ -1,0 +1,52 @@
+package com.project.catxi.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.catxi.chat.domain.ChatMessage;
+import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.chat.dto.ChatMessageSendReq;
+import com.project.catxi.chat.repository.ChatMessageRepository;
+import com.project.catxi.chat.repository.ChatRoomRepository;
+import com.project.catxi.common.api.error.ChatRoomErrorCode;
+import com.project.catxi.common.api.error.MemberErrorCode;
+import com.project.catxi.common.api.exception.CatxiException;
+import com.project.catxi.common.domain.MessageType;
+import com.project.catxi.member.domain.Member;
+import com.project.catxi.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatMessageService {
+
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final MemberRepository memberRepository;
+	private final ChatMessageRepository chatMessageRepository;
+
+
+	public void saveMessage(ChatMessageSendReq req){
+		ChatRoom room = chatRoomRepository.findById(req.roomId())
+			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		Member sender = memberRepository.findById(req.senderId())
+			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		ChatMessage chatMsg = ChatMessage.builder()
+			.chatRoom(room)
+			.member(sender)
+			.content(req.message())
+			.msgType(MessageType.CHAT)
+			.build();
+
+		chatMessageRepository.save(chatMsg);
+	}
+
+
+
+
+
+}

--- a/src/main/java/com/project/catxi/common/api/error/ChatRoomErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/ChatRoomErrorCode.java
@@ -1,0 +1,19 @@
+package com.project.catxi.common.api.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatRoomErrorCode implements ErrorCode{
+
+	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "PORTFOLIO404", "채팅방를 찾을 수 없습니다."),
+	NOT_OWNED_CHATROOM(HttpStatus.FORBIDDEN, "PORTFOLIO403", "본인 소유의 채팅방이 아닙니다."),
+	INVALID_CHATROOM_PARAMETER(HttpStatus.BAD_REQUEST, "PORTFOLIO400", "채팅방 요청 데이터가 올바르지 않습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/project/catxi/common/api/error/MemberErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/MemberErrorCode.java
@@ -1,0 +1,19 @@
+package com.project.catxi.common.api.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode{
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "PORTFOLIO404", "멤버를 찾을 수 없습니다."),
+	INVALID_MEMBER_PARAMETER(HttpStatus.BAD_REQUEST, "PORTFOLIO400", "유효하지 않는 멤버입니다");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+
+}

--- a/src/main/java/com/project/catxi/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/catxi/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.project.catxi.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.project.catxi.member.domain.Member;
+
+public interface MemberRepository   extends JpaRepository<Member, Long> {
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #12 

## 📝작업 내용
메시지 저장 서비스·DTO·엔티티 Builder 적용
- Builder 패턴 채택
 선택·확장 가능 필드(추후 fileUrl, emojiCode)를 고려해 가독성 및 순서 오류 방지.
- 레코드 DTO
 값 전달용으로만 쓰이기 때문에 클래스를 최소화하고 불변 데이터 컨테이너 확보.
- 커스텀 에러코드 사용