### PR TITLE
[FEAT] 채팅방 메시지 히스토리 조회 API 추가

### DIFF
--- a/src/main/java/com/project/catxi/chat/controller/ChatController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatController.java
@@ -1,22 +1,38 @@
 package com.project.catxi.chat.controller;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.catxi.chat.dto.RoomCreateReq;
+import com.project.catxi.chat.dto.RoomCreateRes;
 import com.project.catxi.chat.service.ChatMessageService;
+import com.project.catxi.chat.service.ChatRoomService;
 import com.project.catxi.common.api.ApiResponse;
 import com.project.catxi.common.api.CommonPageResponse;
+import com.project.catxi.member.domain.Member;
 
 @RestController
 @RequestMapping("/chat")
 public class ChatController {
 
 	private final ChatMessageService chatMessageService;
+	private final ChatRoomService chatRoomService;
 
-	public ChatController(ChatMessageService chatMessageService) {
+	public ChatController(ChatMessageService chatMessageService, ChatRoomService chatRoomService) {
 		this.chatMessageService = chatMessageService;
+		this.chatRoomService = chatRoomService;
 	}
+
+	@PostMapping("/room/create")
+	public ResponseEntity<ApiResponse<RoomCreateRes>> createRoom(@RequestBody RoomCreateReq roomCreateReq, Member member){
+		RoomCreateRes res = chatRoomService.creatRoom(roomCreateReq, member);
+		return ResponseEntity.ok(ApiResponse.success(res));
+	}
+
 
 }

--- a/src/main/java/com/project/catxi/chat/controller/ChatController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatController.java
@@ -1,13 +1,19 @@
 package com.project.catxi.chat.controller;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.catxi.chat.dto.ChatMessageRes;
 import com.project.catxi.chat.dto.RoomCreateReq;
 import com.project.catxi.chat.dto.RoomCreateRes;
 import com.project.catxi.chat.service.ChatMessageService;
@@ -29,10 +35,17 @@ public class ChatController {
 	}
 
 	@PostMapping("/room/create")
-	public ResponseEntity<ApiResponse<RoomCreateRes>> createRoom(@RequestBody RoomCreateReq roomCreateReq, Member member){
+	public ResponseEntity<ApiResponse<RoomCreateRes>> createRoom(@RequestBody RoomCreateReq roomCreateReq,
+		Member member) {
 		RoomCreateRes res = chatRoomService.creatRoom(roomCreateReq, member);
 		return ResponseEntity.ok(ApiResponse.success(res));
 	}
 
+	@GetMapping("/{roomId}/messages")
+	public ResponseEntity<ApiResponse<List<ChatMessageRes>>> getHistory(@PathVariable Long roomId, @RequestParam("memberId") Long memberId){
+		List<ChatMessageRes> history =
+			chatMessageService.getChatHistory(roomId, memberId);
 
+		return  ResponseEntity.ok(ApiResponse.success(history));
+	}
 }

--- a/src/main/java/com/project/catxi/chat/controller/ChatController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatController.java
@@ -1,19 +1,22 @@
 package com.project.catxi.chat.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.catxi.chat.service.ChatMessageService;
+import com.project.catxi.common.api.ApiResponse;
+import com.project.catxi.common.api.CommonPageResponse;
 
 @RestController
 @RequestMapping("/chat")
-public class ChatMessageController {
+public class ChatController {
 
 	private final ChatMessageService chatMessageService;
 
-	public ChatMessageController(ChatMessageService chatMessageService) {
+	public ChatController(ChatMessageService chatMessageService) {
 		this.chatMessageService = chatMessageService;
 	}
-
 
 }

--- a/src/main/java/com/project/catxi/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatMessageController.java
@@ -1,0 +1,19 @@
+package com.project.catxi.chat.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.catxi.chat.service.ChatMessageService;
+
+@RestController
+@RequestMapping("/chat")
+public class ChatMessageController {
+
+	private final ChatMessageService chatMessageService;
+
+	public ChatMessageController(ChatMessageService chatMessageService) {
+		this.chatMessageService = chatMessageService;
+	}
+
+
+}

--- a/src/main/java/com/project/catxi/chat/domain/ChatMessage.java
+++ b/src/main/java/com/project/catxi/chat/domain/ChatMessage.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Builder
 public class ChatMessage extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/com/project/catxi/chat/domain/ChatParticipant.java
+++ b/src/main/java/com/project/catxi/chat/domain/ChatParticipant.java
@@ -14,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,6 +28,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Builder
 public class ChatParticipant extends BaseTimeEntity {
 
 	@Id
@@ -45,4 +47,6 @@ public class ChatParticipant extends BaseTimeEntity {
 
 	@Column(nullable = false)
 	private boolean isHost;
+
+	private boolean isActive;
 }

--- a/src/main/java/com/project/catxi/chat/domain/ChatRoom.java
+++ b/src/main/java/com/project/catxi/chat/domain/ChatRoom.java
@@ -16,6 +16,7 @@ import com.project.catxi.member.domain.Member;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class ChatRoom extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/com/project/catxi/chat/dto/ChatMessageRes.java
+++ b/src/main/java/com/project/catxi/chat/dto/ChatMessageRes.java
@@ -1,0 +1,12 @@
+package com.project.catxi.chat.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageRes(
+	Long   messageId,
+	Long   roomId,
+	Long   senderId,
+	String senderName,
+	String content,
+	LocalDateTime sentAt
+) { }

--- a/src/main/java/com/project/catxi/chat/dto/ChatMessageSendReq.java
+++ b/src/main/java/com/project/catxi/chat/dto/ChatMessageSendReq.java
@@ -1,0 +1,7 @@
+package com.project.catxi.chat.dto;
+
+public record ChatMessageSendReq(
+	Long   roomId,
+	Long   senderId,      // Member PK (or 이메일·닉네임으로 변경 가능)
+	String message
+) { }

--- a/src/main/java/com/project/catxi/chat/dto/RoomCreateReq.java
+++ b/src/main/java/com/project/catxi/chat/dto/RoomCreateReq.java
@@ -1,0 +1,13 @@
+package com.project.catxi.chat.dto;
+
+import java.time.LocalDateTime;
+
+import com.project.catxi.common.domain.Location;
+
+public record RoomCreateReq(Location startPoint,
+							Location endPoint,
+							Long recruitSize,
+							LocalDateTime departAt)
+{
+}
+

--- a/src/main/java/com/project/catxi/chat/dto/RoomCreateRes.java
+++ b/src/main/java/com/project/catxi/chat/dto/RoomCreateRes.java
@@ -1,0 +1,15 @@
+package com.project.catxi.chat.dto;
+
+import java.time.LocalDateTime;
+
+import com.project.catxi.common.domain.Location;
+import com.project.catxi.common.domain.RoomStatus;
+
+public record RoomCreateRes(
+	Long    roomId,
+	Location startPoint,
+	Location endPoint,
+	Long recruitSize,
+	LocalDateTime departAt,
+	RoomStatus status
+) { }

--- a/src/main/java/com/project/catxi/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatMessageRepository.java
@@ -1,10 +1,14 @@
 package com.project.catxi.chat.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.project.catxi.chat.domain.ChatMessage;
+import com.project.catxi.chat.domain.ChatRoom;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+	List<ChatMessage> findByChatRoomOrderByCreatedTimeAsc(ChatRoom room);
 
 }
 

--- a/src/main/java/com/project/catxi/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,10 @@
+package com.project.catxi.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.project.catxi.chat.domain.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+}
+

--- a/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
@@ -1,11 +1,20 @@
 package com.project.catxi.chat.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.project.catxi.chat.domain.ChatMessage;
 import com.project.catxi.chat.domain.ChatParticipant;
+import com.project.catxi.chat.domain.ChatRoom;
 import com.project.catxi.member.domain.Member;
 
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant,Long> {
 
 	boolean existsByMemberAndActiveTrue(Member member);
+
+	List<ChatMessage> findByChatRoomOrderByCreatedTimeAsc(ChatRoom room);
+
+	boolean existsByChatRoomAndMember(ChatRoom room, Member member);
+
 }

--- a/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
@@ -1,0 +1,11 @@
+package com.project.catxi.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.project.catxi.chat.domain.ChatParticipant;
+import com.project.catxi.member.domain.Member;
+
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant,Long> {
+
+	boolean existsByMemberAndActiveTrue(Member member);
+}

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.project.catxi.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.project.catxi.chat.domain.ChatRoom;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {}

--- a/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
@@ -1,0 +1,52 @@
+package com.project.catxi.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.catxi.chat.domain.ChatMessage;
+import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.chat.dto.ChatMessageSendReq;
+import com.project.catxi.chat.repository.ChatMessageRepository;
+import com.project.catxi.chat.repository.ChatRoomRepository;
+import com.project.catxi.common.api.error.ChatRoomErrorCode;
+import com.project.catxi.common.api.error.MemberErrorCode;
+import com.project.catxi.common.api.exception.CatxiException;
+import com.project.catxi.common.domain.MessageType;
+import com.project.catxi.member.domain.Member;
+import com.project.catxi.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatMessageService {
+
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final MemberRepository memberRepository;
+	private final ChatMessageRepository chatMessageRepository;
+
+
+	public void saveMessage(ChatMessageSendReq req){
+		ChatRoom room = chatRoomRepository.findById(req.roomId())
+			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		Member sender = memberRepository.findById(req.senderId())
+			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		ChatMessage chatMsg = ChatMessage.builder()
+			.chatRoom(room)
+			.member(sender)
+			.content(req.message())
+			.msgType(MessageType.CHAT)
+			.build();
+
+		chatMessageRepository.save(chatMsg);
+	}
+
+
+
+
+
+}

--- a/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
@@ -1,13 +1,19 @@
 package com.project.catxi.chat.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.project.catxi.chat.domain.ChatMessage;
+import com.project.catxi.chat.domain.ChatParticipant;
 import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.chat.dto.ChatMessageRes;
 import com.project.catxi.chat.dto.ChatMessageSendReq;
 import com.project.catxi.chat.repository.ChatMessageRepository;
+import com.project.catxi.chat.repository.ChatParticipantRepository;
 import com.project.catxi.chat.repository.ChatRoomRepository;
+import com.project.catxi.common.api.error.ChatParticipantErrorCode;
 import com.project.catxi.common.api.error.ChatRoomErrorCode;
 import com.project.catxi.common.api.error.MemberErrorCode;
 import com.project.catxi.common.api.exception.CatxiException;
@@ -22,13 +28,12 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class ChatMessageService {
 
-
 	private final ChatRoomRepository chatRoomRepository;
 	private final MemberRepository memberRepository;
 	private final ChatMessageRepository chatMessageRepository;
+	private final ChatParticipantRepository chatParticipantRepository;
 
-
-	public void saveMessage(ChatMessageSendReq req){
+	public void saveMessage(ChatMessageSendReq req) {
 		ChatRoom room = chatRoomRepository.findById(req.roomId())
 			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
@@ -45,8 +50,29 @@ public class ChatMessageService {
 		chatMessageRepository.save(chatMsg);
 	}
 
+	public List<ChatMessageRes> getChatHistory(Long roomId, Long memberId) {
 
+		ChatRoom room = chatRoomRepository.findById(roomId)
+			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
+		if (!chatParticipantRepository.existsByChatRoomAndMember(room, member)) {
+			throw new CatxiException(ChatParticipantErrorCode.CHATROOM_NOT_FOUND);
+		}
 
+		return chatMessageRepository.findByChatRoomOrderByCreatedTimeAsc(room)
+			.stream()
+			.map(m -> new ChatMessageRes(
+				m.getId(),
+				room.getRoomId(),
+				m.getMember().getId(),
+				m.getMember().getNickname(),
+				m.getContent(),
+				m.getCreatedTime()
+			))
+			.toList();
+
+	}
 }

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -1,0 +1,69 @@
+package com.project.catxi.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.catxi.chat.domain.ChatParticipant;
+import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.chat.dto.RoomCreateReq;
+import com.project.catxi.chat.dto.RoomCreateRes;
+import com.project.catxi.chat.repository.ChatParticipantRepository;
+import com.project.catxi.chat.repository.ChatRoomRepository;
+import com.project.catxi.common.api.error.ChatParticipantErrorCode;
+import com.project.catxi.common.api.error.ChatRoomErrorCode;
+import com.project.catxi.common.api.exception.CatxiException;
+import com.project.catxi.common.domain.RoomStatus;
+import com.project.catxi.member.domain.Member;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatRoomService {
+
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final ChatParticipantRepository chatParticipantRepository;
+
+	private void HostNotInOtherRoom(Member host) {
+		boolean exists = chatParticipantRepository.existsByMemberAndActiveTrue(host);
+		if (exists)
+			throw new CatxiException(ChatParticipantErrorCode.ALREADY_IN_ACTIVE_ROOM);
+	}
+
+	public RoomCreateRes creatRoom(RoomCreateReq roomReq, Member host){
+		HostNotInOtherRoom(host);
+		if(roomReq.startPoint().equals(roomReq.endPoint()))
+			throw new CatxiException(ChatRoomErrorCode.INVALID_CHATROOM_PARAMETER);
+		ChatRoom room = ChatRoom.builder()
+			.host(host)
+			.startPoint(roomReq.startPoint())
+			.endPoint(roomReq.endPoint())
+			.departAt(roomReq.departAt())
+			.status(RoomStatus.WAITING)
+			.maxCapacity(roomReq.recruitSize())
+			.build();
+		chatRoomRepository.save(room);
+
+		ChatParticipant hostPart = ChatParticipant.builder()
+			.chatRoom(room)
+			.member(host)
+			.isHost(true)
+			.ready(true)
+			.isActive(true)
+			.build();
+		chatParticipantRepository.save(hostPart);
+
+		return new RoomCreateRes(
+			room.getRoomId(),
+			room.getStartPoint(),
+			room.getEndPoint(),
+			room.getMaxCapacity(),
+			room.getDepartAt(),
+			room.getStatus()
+		);
+	}
+
+
+}

--- a/src/main/java/com/project/catxi/common/api/error/ChatParticipantErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/ChatParticipantErrorCode.java
@@ -1,0 +1,18 @@
+package com.project.catxi.common.api.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatParticipantErrorCode implements ErrorCode{
+
+	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATPARTICIPANT404", "채팅방를 찾을 수 없습니다."),
+	ALREADY_IN_ACTIVE_ROOM(HttpStatus.CONFLICT,"CHATPARTICIPANT409","이미 참여 중인 채팅방이 있습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/project/catxi/common/api/error/ChatRoomErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/ChatRoomErrorCode.java
@@ -1,0 +1,19 @@
+package com.project.catxi.common.api.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatRoomErrorCode implements ErrorCode{
+
+	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "PORTFOLIO404", "채팅방를 찾을 수 없습니다."),
+	NOT_OWNED_CHATROOM(HttpStatus.FORBIDDEN, "PORTFOLIO403", "본인 소유의 채팅방이 아닙니다."),
+	INVALID_CHATROOM_PARAMETER(HttpStatus.BAD_REQUEST, "PORTFOLIO400", "채팅방 요청 데이터가 올바르지 않습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/project/catxi/common/api/error/ChatRoomErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/ChatRoomErrorCode.java
@@ -9,9 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChatRoomErrorCode implements ErrorCode{
 
-	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "PORTFOLIO404", "채팅방를 찾을 수 없습니다."),
-	NOT_OWNED_CHATROOM(HttpStatus.FORBIDDEN, "PORTFOLIO403", "본인 소유의 채팅방이 아닙니다."),
-	INVALID_CHATROOM_PARAMETER(HttpStatus.BAD_REQUEST, "PORTFOLIO400", "채팅방 요청 데이터가 올바르지 않습니다.");
+	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM404", "채팅방를 찾을 수 없습니다."),
+	NOT_OWNED_CHATROOM(HttpStatus.FORBIDDEN, "CHATROOM403", "본인 소유의 채팅방이 아닙니다."),
+	INVALID_CHATROOM_PARAMETER(HttpStatus.BAD_REQUEST, "CHATROOM400", "채팅방 요청 데이터가 올바르지 않습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/project/catxi/common/api/error/MemberErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/MemberErrorCode.java
@@ -1,0 +1,19 @@
+package com.project.catxi.common.api.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode{
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "PORTFOLIO404", "멤버를 찾을 수 없습니다."),
+	INVALID_MEMBER_PARAMETER(HttpStatus.BAD_REQUEST, "PORTFOLIO400", "유효하지 않는 멤버입니다");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+
+}

--- a/src/main/java/com/project/catxi/common/api/error/MemberErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/MemberErrorCode.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode{
-	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "PORTFOLIO404", "멤버를 찾을 수 없습니다."),
-	INVALID_MEMBER_PARAMETER(HttpStatus.BAD_REQUEST, "PORTFOLIO400", "유효하지 않는 멤버입니다");
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "멤버를 찾을 수 없습니다."),
+	INVALID_MEMBER_PARAMETER(HttpStatus.BAD_REQUEST, "MEMBER400", "유효하지 않는 멤버입니다");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/project/catxi/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/catxi/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.project.catxi.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.project.catxi.member.domain.Member;
+
+public interface MemberRepository   extends JpaRepository<Member, Long> {
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #16 

## 📝작업 내용
채팅방 들어왔을 때 이전 채팅 내용도 계속 조회되기 위한 API 추가했습니다.

```html
GET /api/v1/rooms/15/messages?memberId=7   -> 200 OK
[
  {
    "messageId": 31,
    "roomId": 15,
    "senderId": 7,
    "senderName": "이*준",
    "content": "출발시간 10분 전입니다!",
    "sentAt": "2025-05-11T09:40:03"
  },
  ...
]
``` 