### PR TITLE
[FEAT] 채팅방 참여 API 구현

### DIFF
--- a/src/main/java/com/project/catxi/chat/controller/ChatController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatController.java
@@ -48,4 +48,15 @@ public class ChatController {
 
 		return  ResponseEntity.ok(ApiResponse.success(history));
 	}
+
+	@PostMapping("/rooms/{roomId}/join")
+	public ResponseEntity<ApiResponse<Void>> joinChatRoom(
+		@PathVariable Long roomId,
+		@RequestParam Long memberId) {
+
+		chatRoomService.joinChatRoom(roomId, memberId);
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
+
 }

--- a/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
@@ -17,4 +17,6 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 
 	boolean existsByChatRoomAndMember(ChatRoom room, Member member);
 
+	long countByChatRoomAndActiveTrue(ChatRoom room);
+
 }

--- a/src/main/java/com/project/catxi/common/api/error/ChatRoomErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/ChatRoomErrorCode.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChatRoomErrorCode implements ErrorCode{
 
+	CHATROOM_FULL(HttpStatus.NOT_FOUND, "CHATROOM405", "채팅방에 인원이 꽉찼습니다."),
 	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM404", "채팅방를 찾을 수 없습니다."),
 	NOT_OWNED_CHATROOM(HttpStatus.FORBIDDEN, "CHATROOM403", "본인 소유의 채팅방이 아닙니다."),
 	INVALID_CHATROOM_PARAMETER(HttpStatus.BAD_REQUEST, "CHATROOM400", "채팅방 요청 데이터가 올바르지 않습니다.");


### PR DESCRIPTION
## #️⃣연관된 이슈

> #18 
(그 전 커밋도 같이 들어왔네요,,맨 마지막 커밋만 보시면 됩니다.)

## 📝작업 내용
채팅방 참여 API 구현해보았습니다.
다른 방 참여 중인지 확인 -> 방 (정원,상태) 체크 -> 참가자 저장