### PR TITLE
[FEAT] 채팅방 나가기 API 구현

### DIFF
--- a/src/main/java/com/project/catxi/chat/controller/ChatController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatController.java
@@ -2,9 +2,8 @@ package com.project.catxi.chat.controller;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,7 +18,6 @@ import com.project.catxi.chat.dto.RoomCreateRes;
 import com.project.catxi.chat.service.ChatMessageService;
 import com.project.catxi.chat.service.ChatRoomService;
 import com.project.catxi.common.api.ApiResponse;
-import com.project.catxi.common.api.CommonPageResponse;
 import com.project.catxi.member.domain.Member;
 
 @RestController
@@ -47,5 +45,14 @@ public class ChatController {
 			chatMessageService.getChatHistory(roomId, memberId);
 
 		return  ResponseEntity.ok(ApiResponse.success(history));
+	}
+
+	@DeleteMapping("/{roomId}/leave")
+	public ResponseEntity<ApiResponse<Void>> leaveRoom(
+		@PathVariable Long roomId,
+		@RequestParam  Long memberId) {      // 임시 – 로그인 완성 후 제거
+
+		chatRoomService.leaveChatRoom(roomId, memberId);
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
 	}
 }

--- a/src/main/java/com/project/catxi/chat/domain/ChatParticipant.java
+++ b/src/main/java/com/project/catxi/chat/domain/ChatParticipant.java
@@ -43,10 +43,18 @@ public class ChatParticipant extends BaseTimeEntity {
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
 
-	private boolean ready;
+	private boolean isReady;
 
 	@Column(nullable = false)
 	private boolean isHost;
 
 	private boolean isActive;
+
+	public void setActive(boolean active) {
+		isActive = active;
+	}
+
+	public void setReady(boolean ready) {
+		isReady=ready;
+	}
 }

--- a/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
@@ -1,6 +1,7 @@
 package com.project.catxi.chat.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -16,5 +17,8 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 	List<ChatMessage> findByChatRoomOrderByCreatedTimeAsc(ChatRoom room);
 
 	boolean existsByChatRoomAndMember(ChatRoom room, Member member);
+
+	Optional<ChatParticipant> findByChatRoomAndMemberAndActiveTrue(ChatRoom room, Member member);
+
 
 }

--- a/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
@@ -59,7 +59,7 @@ public class ChatMessageService {
 			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
 		if (!chatParticipantRepository.existsByChatRoomAndMember(room, member)) {
-			throw new CatxiException(ChatParticipantErrorCode.CHATROOM_NOT_FOUND);
+			throw new CatxiException(ChatParticipantErrorCode.PARTICIPANT_NOT_FOUND);
 		}
 
 		return chatMessageRepository.findByChatRoomOrderByCreatedTimeAsc(room)

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -1,5 +1,7 @@
 package com.project.catxi.chat.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,10 +13,13 @@ import com.project.catxi.chat.repository.ChatParticipantRepository;
 import com.project.catxi.chat.repository.ChatRoomRepository;
 import com.project.catxi.common.api.error.ChatParticipantErrorCode;
 import com.project.catxi.common.api.error.ChatRoomErrorCode;
+import com.project.catxi.common.api.error.MemberErrorCode;
 import com.project.catxi.common.api.exception.CatxiException;
 import com.project.catxi.common.domain.RoomStatus;
 import com.project.catxi.member.domain.Member;
+import com.project.catxi.member.repository.MemberRepository;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -25,6 +30,7 @@ public class ChatRoomService {
 
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatParticipantRepository chatParticipantRepository;
+	private final MemberRepository memberRepository;
 
 	private void HostNotInOtherRoom(Member host) {
 		boolean exists = chatParticipantRepository.existsByMemberAndActiveTrue(host);
@@ -50,7 +56,7 @@ public class ChatRoomService {
 			.chatRoom(room)
 			.member(host)
 			.isHost(true)
-			.ready(true)
+			.isReady(true)
 			.isActive(true)
 			.build();
 		chatParticipantRepository.save(hostPart);
@@ -64,6 +70,25 @@ public class ChatRoomService {
 			room.getStatus()
 		);
 	}
+
+	//로그인 전이라 member 임시로 추가해둠.
+	public void leaveChatRoom(Long roomId,Long memberId){
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
+		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+		ChatParticipant chatParticipant = chatParticipantRepository
+			.findByChatRoomAndMemberAndActiveTrue(chatRoom, member)
+			.orElseThrow(() -> new CatxiException(ChatParticipantErrorCode.PARTICIPANT_NOT_FOUND));
+		if (chatParticipant.isHost()) {
+			chatRoomRepository.delete(chatRoom);
+			return;
+		}
+
+		chatParticipant.setActive(false);
+		chatParticipant.setReady(false);
+	}
+
 
 
 }

--- a/src/main/java/com/project/catxi/common/api/error/ChatParticipantErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/ChatParticipantErrorCode.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChatParticipantErrorCode implements ErrorCode{
 
-	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATPARTICIPANT404", "채팅방를 찾을 수 없습니다."),
+	PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATPARTICIPANT404", "채팅방 참여자를 찾을 수 없습니다."),
 	ALREADY_IN_ACTIVE_ROOM(HttpStatus.CONFLICT,"CHATPARTICIPANT409","이미 참여 중인 채팅방이 있습니다.");
 
 	private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ) #21 

## 📝작업 내용
채팅방 나가기 API 구현했습니다
- 방장이면 방을 아예 삭제합니다.
- 일반 유저면 setActive(false) , setReady(false) 한 후 나가게 됩니다.