### PR TITLE
[FEAT] 채팅방 목록 조회 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ out/
 ### application.properties ###
 src/main/resources/application-local.yml
 
+### QueryDSL ###
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 
-def generated = 'src/main/generated'
+def generated = 'build/generated/querydsl'
 
 tasks.withType(JavaCompile) {
 	options.getGeneratedSourceOutputDirectory().set(file(generated))

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,27 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Querydsl 추가 (Spring boot 3.x 이상)
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+
+def generated = 'src/main/generated'
+
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+clean {
+	delete file(generated)
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/catxi/chat/controller/ChatController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatController.java
@@ -2,8 +2,6 @@ package com.project.catxi.chat.controller;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,12 +12,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.catxi.chat.dto.ChatMessageRes;
+import com.project.catxi.chat.dto.ChatRoomRes;
 import com.project.catxi.chat.dto.RoomCreateReq;
 import com.project.catxi.chat.dto.RoomCreateRes;
 import com.project.catxi.chat.service.ChatMessageService;
 import com.project.catxi.chat.service.ChatRoomService;
 import com.project.catxi.common.api.ApiResponse;
-import com.project.catxi.common.api.CommonPageResponse;
 import com.project.catxi.member.domain.Member;
 
 @RestController
@@ -48,4 +46,18 @@ public class ChatController {
 
 		return  ResponseEntity.ok(ApiResponse.success(history));
 	}
+
+
+	@GetMapping("/rooms")
+	public ResponseEntity<ApiResponse<List<ChatRoomRes>>> getRoomList(
+		@RequestParam("direction") String direction,
+		@RequestParam("station")String station,
+		@RequestParam("sort") String sort,
+		@RequestParam(value = "page", defaultValue = "0") int page
+	){
+		List<ChatRoomRes> roomList = chatRoomService.getChatRoomList(direction,station, sort, page);
+		return ResponseEntity.ok(ApiResponse.success(roomList));
+	}
+
+
 }

--- a/src/main/java/com/project/catxi/chat/controller/ChatController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatController.java
@@ -2,6 +2,7 @@ package com.project.catxi.chat.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +20,7 @@ import com.project.catxi.chat.dto.RoomCreateRes;
 import com.project.catxi.chat.service.ChatMessageService;
 import com.project.catxi.chat.service.ChatRoomService;
 import com.project.catxi.common.api.ApiResponse;
+import com.project.catxi.common.api.CommonPageResponse;
 import com.project.catxi.member.domain.Member;
 
 @RestController
@@ -49,14 +51,14 @@ public class ChatController {
 	}
 
 	@GetMapping("/rooms")
-	public ResponseEntity<ApiResponse<List<ChatRoomRes>>> getRoomList(
+	public ResponseEntity<ApiResponse<CommonPageResponse<ChatRoomRes>>> getRoomList(
 		@RequestParam("direction") String direction,
 		@RequestParam("station")String station,
 		@RequestParam("sort") String sort,
 		@RequestParam(value = "page", defaultValue = "0") int page
 	) {
-		List<ChatRoomRes> roomList = chatRoomService.getChatRoomList(direction, station, sort, page);
-		return ResponseEntity.ok(ApiResponse.success(roomList));
+		Page<ChatRoomRes> roomList = chatRoomService.getChatRoomList(direction, station, sort, page);
+		return ResponseEntity.ok(ApiResponse.success(CommonPageResponse.of(roomList)));
 	}
 
 	@DeleteMapping("/{roomId}/leave")

--- a/src/main/java/com/project/catxi/chat/dto/ChatRoomRes.java
+++ b/src/main/java/com/project/catxi/chat/dto/ChatRoomRes.java
@@ -1,5 +1,6 @@
 package com.project.catxi.chat.dto;
 
+import com.project.catxi.chat.domain.ChatRoom;
 import com.project.catxi.common.domain.Location;
 import com.project.catxi.common.domain.RoomStatus;
 
@@ -15,4 +16,20 @@ public record ChatRoomRes (
 	RoomStatus status,
 	String departAt,
 	String createdTime
-){ }
+){
+	public static ChatRoomRes from (ChatRoom chatRoom){
+		return new ChatRoomRes(
+			chatRoom.getRoomId(),
+			chatRoom.getHost().getId(),
+			chatRoom.getHost().getName(),
+			chatRoom.getHost().getNickname(),
+			chatRoom.getStartPoint(),
+			chatRoom.getEndPoint(),
+			chatRoom.getMaxCapacity(),
+			(long)chatRoom.getParticipants().size(),
+			chatRoom.getStatus(),
+			chatRoom.getDepartAt().toString(),
+			chatRoom.getCreatedTime().toString()
+		);
+	}
+}

--- a/src/main/java/com/project/catxi/chat/dto/ChatRoomRes.java
+++ b/src/main/java/com/project/catxi/chat/dto/ChatRoomRes.java
@@ -1,0 +1,18 @@
+package com.project.catxi.chat.dto;
+
+import com.project.catxi.common.domain.Location;
+import com.project.catxi.common.domain.RoomStatus;
+
+public record ChatRoomRes (
+	Long roomId,
+	Long hostId,
+	String hostName,
+	String hostNickname,
+	Location startPoint,
+	Location endPoint,
+	Long recruitSize,
+	Long currentSize,
+	RoomStatus status,
+	String departAt,
+	String createdTime
+){ }

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepository.java
@@ -4,4 +4,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.project.catxi.chat.domain.ChatRoom;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {}
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomRepositoryCustom {}

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.project.catxi.chat.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.common.domain.Location;
+
+public interface ChatRoomRepositoryCustom {
+	List<ChatRoom> findByLocationAndDirection(Location location, String point, Pageable pageable);
+}

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustom.java
@@ -2,11 +2,12 @@ package com.project.catxi.chat.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.project.catxi.chat.domain.ChatRoom;
 import com.project.catxi.common.domain.Location;
 
 public interface ChatRoomRepositoryCustom {
-	List<ChatRoom> findByLocationAndDirection(Location location, String point, Pageable pageable);
+	Page<ChatRoom> findByLocationAndDirection(Location location, String point, Pageable pageable);
 }

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustom.java
@@ -1,13 +1,11 @@
 package com.project.catxi.chat.repository;
 
-import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-
-import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.chat.dto.ChatRoomRes;
 import com.project.catxi.common.domain.Location;
 
 public interface ChatRoomRepositoryCustom {
-	Page<ChatRoom> findByLocationAndDirection(Location location, String point, Pageable pageable);
+	Page<ChatRoomRes> findByLocationAndDirection(Location location, String point, Pageable pageable);
 }

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.project.catxi.chat.repository;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -65,7 +66,7 @@ public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom {
 				chatRoom.status.eq(RoomStatus.WAITING),
 				filterByLocationAndPoint(location, point)
 			)
-			.orderBy(getOrderSpecifier(pageable))
+			.orderBy(getOrderSpecifier(pageable.getSort()))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();
@@ -86,15 +87,16 @@ public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom {
 		);
 	}
 
-	private OrderSpecifier<?> getOrderSpecifier(Pageable pageable) {
-		Sort.Order order = pageable.getSort().iterator().next();
-		PathBuilder<ChatRoom> path = new PathBuilder<>(ChatRoom.class, "chatRoom");
-		String property = order.getProperty();
+	private OrderSpecifier<?>[] getOrderSpecifier(Sort sort) {
+		List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
 
-		return new OrderSpecifier<>(
-			order.isAscending() ? Order.ASC : Order.DESC,
-			path.getComparable(property, Comparable.class)
-		);
+		for (Sort.Order order : sort) {
+			Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+			PathBuilder<ChatRoom> pathBuilder = new PathBuilder<>(ChatRoom.class, "chatRoom");
+			orderSpecifiers.add(new OrderSpecifier<>(direction, pathBuilder.getString(order.getProperty())));
+		}
+
+		return orderSpecifiers.toArray(new OrderSpecifier[0]);
 	}
 
 	private BooleanExpression filterByLocationAndPoint(Location location, String point) {

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
@@ -53,19 +53,19 @@ public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom {
 				chatRoom.startPoint,
 				chatRoom.endPoint,
 				chatRoom.maxCapacity,
-				JPAExpressions.select(participant.count())
-					.from(participant)
-					.where(participant.chatRoom.eq(chatRoom)),
+				participant.id.countDistinct(),
 				chatRoom.status,
 				chatRoom.departAt.stringValue(),
 				chatRoom.createdTime.stringValue()
 			))
 			.from(chatRoom)
 			.join(chatRoom.host, host)
+			.leftJoin(chatRoom.participants, participant)
 			.where(
 				chatRoom.status.eq(RoomStatus.WAITING),
 				filterByLocationAndPoint(location, point)
 			)
+			.groupBy(chatRoom.roomId)
 			.orderBy(getOrderSpecifier(pageable.getSort()))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
@@ -1,0 +1,76 @@
+package com.project.catxi.chat.repository;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.chat.domain.QChatRoom;
+import com.project.catxi.common.api.error.ChatRoomErrorCode;
+import com.project.catxi.common.api.exception.CatxiException;
+import com.project.catxi.common.domain.Location;
+import com.project.catxi.common.domain.RoomStatus;
+import com.project.catxi.member.domain.QMember;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.EnumPath;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<ChatRoom> findByLocationAndDirection(Location location, String point, Pageable pageable) {
+		QChatRoom chatRoom = QChatRoom.chatRoom;
+
+		return jpaQueryFactory
+			.selectFrom(chatRoom)
+			.join(chatRoom.host, QMember.member).fetchJoin()
+			.where(filterByLocationAndPoint(location, point), chatRoom.status.eq(RoomStatus.WAITING))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(getOrderSpecifier(pageable))
+			.fetch();
+	}
+
+	private OrderSpecifier<?> getOrderSpecifier(Pageable pageable) {
+		Sort.Order order = pageable.getSort().iterator().next();
+		PathBuilder<ChatRoom> path = new PathBuilder<>(ChatRoom.class, "chatRoom");
+		String property = order.getProperty();
+
+		return new OrderSpecifier<>(
+			order.isAscending() ? Order.ASC : Order.DESC,
+			path.getComparable(property, Comparable.class)
+		);
+	}
+
+	private BooleanExpression filterByLocationAndPoint(Location location, String point) {
+		QChatRoom chatRoom = QChatRoom.chatRoom;
+		if (point.equals("TO_SCHOOL")) {
+			return filterByLocation(chatRoom.startPoint, location);
+		} else if (point.equals("FROM_SCHOOL")) {
+			return filterByLocation(chatRoom.endPoint, location);
+		} else {
+			throw new CatxiException(ChatRoomErrorCode.INVALID_CHATROOM_PARAMETER);
+		}
+	}
+
+	private BooleanExpression filterByLocation(EnumPath<Location> path, Location location){
+		Set<Location> locations = Set.of(Location.GURO_ST, Location.BUCHEON_ST, Location.SINDORIM_ST);
+		if(locations.contains(location))
+			return path.in(locations);
+		else
+			return path.eq(location);
+	}
+
+
+}

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
@@ -67,8 +67,6 @@ public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom {
 			)
 			.groupBy(chatRoom.roomId)
 			.orderBy(getOrderSpecifier(pageable.getSort()))
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
 			.fetch();
 
 		// 2. 전체 데이터 개수 조회

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -2,6 +2,7 @@ package com.project.catxi.chat.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -76,7 +77,7 @@ public class ChatRoomService {
 	}
 
 
-	public List<ChatRoomRes> getChatRoomList(String direction, String station, String sort, Integer page) {
+	public Page<ChatRoomRes> getChatRoomList(String direction, String station, String sort, Integer page) {
 		Pageable pageable = PageRequest.of(page, 10, Sort.by(sort));
 
 		Location location = switch (station) {
@@ -85,11 +86,9 @@ public class ChatRoomService {
 			default -> Location.GURO_ST;
 		};
 
-		List<ChatRoom> chatRooms = chatRoomRepository.findByLocationAndDirection(location, direction, pageable);
+		Page<ChatRoom> chatRooms = chatRoomRepository.findByLocationAndDirection(location, direction, pageable);
 
-		return chatRooms.stream()
-			.map(ChatRoomRes::from)
-			.toList();
+		return chatRooms.map(ChatRoomRes::from);
 	}
 
 

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -1,10 +1,16 @@
 package com.project.catxi.chat.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.project.catxi.chat.domain.ChatParticipant;
 import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.chat.dto.ChatRoomRes;
 import com.project.catxi.chat.dto.RoomCreateReq;
 import com.project.catxi.chat.dto.RoomCreateRes;
 import com.project.catxi.chat.repository.ChatParticipantRepository;
@@ -12,6 +18,7 @@ import com.project.catxi.chat.repository.ChatRoomRepository;
 import com.project.catxi.common.api.error.ChatParticipantErrorCode;
 import com.project.catxi.common.api.error.ChatRoomErrorCode;
 import com.project.catxi.common.api.exception.CatxiException;
+import com.project.catxi.common.domain.Location;
 import com.project.catxi.common.domain.RoomStatus;
 import com.project.catxi.member.domain.Member;
 
@@ -63,6 +70,35 @@ public class ChatRoomService {
 			room.getDepartAt(),
 			room.getStatus()
 		);
+	}
+
+
+	public List<ChatRoomRes> getChatRoomList(String direction, String station, String sort, Integer page) {
+		Pageable pageable = PageRequest.of(page, 10, Sort.by(sort));
+
+		Location location = switch (station) {
+			case "SOSA_ST" -> Location.SOSA_ST;
+			case "YEOKGOK_ST" -> Location.YEOKGOK_ST;
+			default -> Location.GURO_ST;
+		};
+
+		List<ChatRoom> chatRooms = chatRoomRepository.findByLocationAndDirection(location, direction, pageable);
+
+		return chatRooms.stream()
+			.map(room -> new ChatRoomRes(
+				room.getRoomId(),
+				room.getHost().getId(),
+				room.getHost().getName(),
+				room.getHost().getNickname(),
+				room.getStartPoint(),
+				room.getEndPoint(),
+				room.getMaxCapacity(),
+				(long) room.getParticipants().size(),
+				room.getStatus(),
+				room.getDepartAt().toString(),
+				room.getCreatedTime().toString()
+			))
+			.toList();
 	}
 
 

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -96,19 +96,7 @@ public class ChatRoomService {
 		List<ChatRoom> chatRooms = chatRoomRepository.findByLocationAndDirection(location, direction, pageable);
 
 		return chatRooms.stream()
-			.map(room -> new ChatRoomRes(
-				room.getRoomId(),
-				room.getHost().getId(),
-				room.getHost().getName(),
-				room.getHost().getNickname(),
-				room.getStartPoint(),
-				room.getEndPoint(),
-				room.getMaxCapacity(),
-				(long) room.getParticipants().size(),
-				room.getStatus(),
-				room.getDepartAt().toString(),
-				room.getCreatedTime().toString()
-			))
+			.map(ChatRoomRes::from)
 			.toList();
 	}
 

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -1,15 +1,10 @@
 package com.project.catxi.chat.service;
 
-import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-
-import java.util.List;
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -86,9 +81,7 @@ public class ChatRoomService {
 			default -> Location.GURO_ST;
 		};
 
-		Page<ChatRoom> chatRooms = chatRoomRepository.findByLocationAndDirection(location, direction, pageable);
-
-		return chatRooms.map(ChatRoomRes::from);
+		return chatRoomRepository.findByLocationAndDirection(location, direction, pageable);
 	}
 
 

--- a/src/main/java/com/project/catxi/common/config/QuerydslConfig.java
+++ b/src/main/java/com/project/catxi/common/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package com.project.catxi.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+	private final EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(){
+		return new JPAQueryFactory(entityManager);
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- QueryDSL 초기세팅
- 채팅방 목록 조회 API

`./gradlew build -x test` 혹은 `./gradlew bootJar -x test` 실행하면 /build/generated/querydsl 폴더에 Qclass 생성됩니다.
`./graldew clean` 시 제거됩니다.

N+1 문제 발생하는 부분은 QueryDSL에서 DTO로 변환하는 방식 중 생성자 기반인 Projections.constructor 사용했습니다.

파라미터로 넘겨 받는 내용은 아래 적어 놨습니다
- direction : TO_SCHOOL, FROM_SCHOOL
- station : SOSA_ST, YEOKGOK_ST, ETC
- sort : departAt, createdTime
- page

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?