### PR TITLE
[Fix] ChatParticipant 유니크 제약 수정

### DIFF
--- a/src/main/java/com/project/catxi/chat/domain/ChatParticipant.java
+++ b/src/main/java/com/project/catxi/chat/domain/ChatParticipant.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(
 	name = "chat_participant",
 	uniqueConstraints = {
-		@UniqueConstraint(name = "uk_participant_member", columnNames = "member_id")
+		@UniqueConstraint(name = "uk_participant_member", columnNames = { "member_id", "active" })
 	}
 )
 @NoArgsConstructor

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
@@ -23,6 +23,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.JPAExpressions;
@@ -53,7 +54,10 @@ public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom {
 				chatRoom.startPoint,
 				chatRoom.endPoint,
 				chatRoom.maxCapacity,
-				participant.id.countDistinct(),
+				new CaseBuilder()
+					.when(participant.active.isTrue()).then(1)
+					.otherwise(0)
+					.sum().longValue(),
 				chatRoom.status,
 				chatRoom.departAt.stringValue(),
 				chatRoom.createdTime.stringValue()


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #33 

## 📝작업 내용
- ChatParticipant unique 제약 
  - member_id -> {member_id, active} 로 변경

- 채팅방 참여자 조회 시 active 활성 상태만 count

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?