### PR TITLE
[REFACT] JWT 기반 인증 구조에 맞게 membername 기반 인증 적용

### DIFF
--- a/src/main/java/com/project/catxi/chat/controller/ChatController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatController.java
@@ -47,11 +47,14 @@ public class ChatController {
 
 
 	@GetMapping("/{roomId}/messages")
-	public ResponseEntity<ApiResponse<List<ChatMessageRes>>> getHistory(@PathVariable Long roomId, @RequestParam("memberId") Long memberId){
-		List<ChatMessageRes> history =
-			chatMessageService.getChatHistory(roomId, memberId);
+	public ResponseEntity<ApiResponse<List<ChatMessageRes>>> getHistory(
+		@PathVariable Long roomId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
 
-		return  ResponseEntity.ok(ApiResponse.success(history));
+		String membername = userDetails.getUsername();
+		List<ChatMessageRes> history = chatMessageService.getChatHistory(roomId, membername);
+
+		return ResponseEntity.ok(ApiResponse.success(history));
 	}
 
 	@GetMapping("/rooms")
@@ -68,18 +71,20 @@ public class ChatController {
 	@DeleteMapping("/{roomId}/leave")
 	public ResponseEntity<ApiResponse<Void>> leaveRoom(
 		@PathVariable Long roomId,
-		@RequestParam  Long memberId) {      // 임시 – 로그인 완성 후 제거
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
 
-		chatRoomService.leaveChatRoom(roomId, memberId);
+		String membername = userDetails.getUsername();
+		chatRoomService.leaveChatRoom(roomId, membername);
 		return ResponseEntity.ok(ApiResponse.successWithNoData());
 	}
 
 	@PostMapping("/rooms/{roomId}/join")
 	public ResponseEntity<ApiResponse<Void>> joinChatRoom(
 		@PathVariable Long roomId,
-		@RequestParam Long memberId) {
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
 
-		chatRoomService.joinChatRoom(roomId, memberId);
+		String membername = userDetails.getUsername();
+		chatRoomService.joinChatRoom(roomId, membername);
 		return ResponseEntity.ok(ApiResponse.successWithNoData());
 	}
 

--- a/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
@@ -50,13 +50,13 @@ public class ChatMessageService {
 		chatMessageRepository.save(chatMsg);
 	}
 
-	public List<ChatMessageRes> getChatHistory(Long roomId, Long memberId) {
+	public List<ChatMessageRes> getChatHistory(Long roomId, String membername) {
+
+		Member member = memberRepository.findByMembername(membername)
+			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
 		ChatRoom room = chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
-
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
 		if (!chatParticipantRepository.existsByChatRoomAndMember(room, member)) {
 			throw new CatxiException(ChatParticipantErrorCode.PARTICIPANT_NOT_FOUND);

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -92,9 +92,8 @@ public class ChatRoomService {
 
 
 	//로그인 전이라 member 임시로 추가해둠.
-	public void leaveChatRoom(Long roomId,Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
+	public void leaveChatRoom(Long roomId, String membername) {
+		Member member = memberRepository.findByMembername(membername).orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
 		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 		ChatParticipant chatParticipant = chatParticipantRepository
@@ -109,17 +108,16 @@ public class ChatRoomService {
 		chatParticipant.setReady(false);
 	}
 
-	public void joinChatRoom(Long roomId, Long memberId) {
-
+	public void joinChatRoom(Long roomId, String membername) {
 		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
-		Member member = memberRepository.findById(memberId)
+		Member member = memberRepository.findByMembername(membername)
 			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
 		HostNotInOtherRoom(member);
 
-		if(chatRoom.getStatus()!=RoomStatus.WAITING)
+		if(chatRoom.getStatus() != RoomStatus.WAITING)
 			throw new CatxiException(ChatRoomErrorCode.INVALID_CHATROOM_PARAMETER);
 
 		long current = chatParticipantRepository.countByChatRoomAndActiveTrue(chatRoom);
@@ -134,6 +132,7 @@ public class ChatRoomService {
 
 		chatParticipantRepository.save(chatParticipant);
 	}
+
 
 	private void HostNotInOtherRoom(Member host) {
 		boolean exists = chatParticipantRepository.existsByMemberAndActiveTrue(host);


### PR DESCRIPTION
## #️⃣연관된 이슈

#38 

## 📝작업 내용
- JWT 내 포함된 정보(membername)를 기반으로 인증 처리
- 기존에는 컨트롤러 및 서비스에서 memberId를 명시적으로 받았으나, JWT에는 memberId가 없고 membername만 포함되어 있어, 이를 기준으로 회원 식별 방식 통일
- 컨트롤러에서 @AuthenticationPrincipal을 활용해 인증 정보 주입
- CustomUserDetails.getUsername() → membername을 통해 로그인된 사용자를 조회

- ChatRoomService 등 내부 로직도 memberId 대신 membername 기준으로 조회하도록 수정

### _**앞으로 API 작성 시 주의사항:**_
JWT 안에 담긴 정보를 기준으로 서비스 로직을 구성해야 합니다.
현재 JWT에는 membername, type, role만 포함되어 있으므로, id 등의 정보가 필요하면 DB에서 조회하도록 처리하세요.

컨트롤러 단에서는 되도록 @AuthenticationPrincipal로 유저 정보를 주입받고, 요청 파라미터로 memberId를 받지 않도록 통일해주세요.
보안상 JWT 기반 인증 구조에서는 사용자 식별 정보를 클라이언트로부터 받는 것은 피해야 합니다.

다른 서비스도 점진적으로 memberId 기반에서 membername 기반 인증 흐름으로 마이그레이션 할 예정입니다. PR 시 이 점 고려해주세요.
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?