### PR TITLE
[FIX] ChatParticipant Unique 제약 조건 및 active 필드 제거

### DIFF
--- a/src/main/java/com/project/catxi/chat/domain/ChatParticipant.java
+++ b/src/main/java/com/project/catxi/chat/domain/ChatParticipant.java
@@ -11,20 +11,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(
-	name = "chat_participant",
-	uniqueConstraints = {
-		@UniqueConstraint(name = "uk_participant_member", columnNames = { "member_id", "active" })
-	}
-)
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -47,12 +39,6 @@ public class ChatParticipant extends BaseTimeEntity {
 
 	@Column(nullable = false)
 	private boolean isHost;
-
-	private boolean active;
-
-	public void setActive(boolean isActive) {
-		active = isActive;
-	}
 
 	public void setReady(boolean ready) {
 		isReady=ready;

--- a/src/main/java/com/project/catxi/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatMessageRepository.java
@@ -10,5 +10,6 @@ import com.project.catxi.chat.domain.ChatRoom;
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 	List<ChatMessage> findByChatRoomOrderByCreatedTimeAsc(ChatRoom room);
 
+	void deleteAllByChatRoom(ChatRoom chatRoom);
 }
 

--- a/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
@@ -12,17 +12,17 @@ import com.project.catxi.member.domain.Member;
 
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant,Long> {
 
-	boolean existsByMemberAndActiveTrue(Member member);
+	boolean existsByMember(Member member);
 
 	List<ChatMessage> findByChatRoomOrderByCreatedTimeAsc(ChatRoom room);
 
 	boolean existsByChatRoomAndMember(ChatRoom room, Member member);
 
 
-	Optional<ChatParticipant> findByChatRoomAndMemberAndActiveTrue(ChatRoom room, Member member);
+	Optional<ChatParticipant> findByChatRoomAndMember(ChatRoom room, Member member);
 
 
-	long countByChatRoomAndActiveTrue(ChatRoom room);
+	long countByChatRoom(ChatRoom room);
 
 
 	List<ChatParticipant> findByChatRoom(ChatRoom chatRoom);

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
@@ -54,10 +54,7 @@ public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom {
 				chatRoom.startPoint,
 				chatRoom.endPoint,
 				chatRoom.maxCapacity,
-				new CaseBuilder()
-					.when(participant.active.isTrue()).then(1)
-					.otherwise(0)
-					.sum().longValue(),
+				participant.id.countDistinct(),
 				chatRoom.status,
 				chatRoom.departAt.stringValue(),
 				chatRoom.createdTime.stringValue()

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -98,15 +98,14 @@ public class ChatRoomService {
 		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 		ChatParticipant chatParticipant = chatParticipantRepository
-			.findByChatRoomAndMemberAndActiveTrue(chatRoom, member)
+			.findByChatRoomAndMember(chatRoom, member)
 			.orElseThrow(() -> new CatxiException(ChatParticipantErrorCode.PARTICIPANT_NOT_FOUND));
 		if (chatParticipant.isHost()) {
 			chatRoomRepository.delete(chatRoom);
 			return;
 		}
 
-		chatParticipant.setActive(false);
-		chatParticipant.setReady(false);
+		chatParticipantRepository.delete(chatParticipant);
 	}
 
 	public void joinChatRoom(Long roomId, String membername) {

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -64,7 +64,6 @@ public class ChatRoomService {
 			.member(host)
 			.isHost(true)
 			.isReady(true)
-			.active(true)
 			.build();
 		chatParticipantRepository.save(hostPart);
 
@@ -120,14 +119,13 @@ public class ChatRoomService {
 		if(chatRoom.getStatus() != RoomStatus.WAITING)
 			throw new CatxiException(ChatRoomErrorCode.INVALID_CHATROOM_PARAMETER);
 
-		long current = chatParticipantRepository.countByChatRoomAndActiveTrue(chatRoom);
+		long current = chatParticipantRepository.countByChatRoom(chatRoom);
 		if (current >= chatRoom.getMaxCapacity())
 			throw new CatxiException(ChatRoomErrorCode.CHATROOM_FULL);
 
 		ChatParticipant chatParticipant = ChatParticipant.builder()
 			.chatRoom(chatRoom)
 			.member(member)
-			.active(true)
 			.build();
 
 		chatParticipantRepository.save(chatParticipant);
@@ -135,9 +133,9 @@ public class ChatRoomService {
 
 
 	private void HostNotInOtherRoom(Member host) {
-		boolean exists = chatParticipantRepository.existsByMemberAndActiveTrue(host);
+		boolean exists = chatParticipantRepository.existsByMember(host);
 		if (exists)
-			throw new CatxiException(ChatParticipantErrorCode.ALREADY_IN_ACTIVE_ROOM);
+			throw new CatxiException(ChatParticipantErrorCode.ALREADY_IN_ROOM);
 
 	}
 

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -15,6 +15,7 @@ import com.project.catxi.chat.domain.ChatRoom;
 import com.project.catxi.chat.dto.ChatRoomRes;
 import com.project.catxi.chat.dto.RoomCreateReq;
 import com.project.catxi.chat.dto.RoomCreateRes;
+import com.project.catxi.chat.repository.ChatMessageRepository;
 import com.project.catxi.chat.repository.ChatParticipantRepository;
 import com.project.catxi.chat.repository.ChatRoomRepository;
 import com.project.catxi.common.api.error.ChatParticipantErrorCode;
@@ -37,6 +38,7 @@ public class ChatRoomService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatParticipantRepository chatParticipantRepository;
 	private final MemberRepository memberRepository;
+	private final ChatMessageRepository chatMessageRepository;
 
 
 	public RoomCreateRes createRoom(RoomCreateReq roomReq, String membername) {
@@ -100,6 +102,7 @@ public class ChatRoomService {
 			.findByChatRoomAndMember(chatRoom, member)
 			.orElseThrow(() -> new CatxiException(ChatParticipantErrorCode.PARTICIPANT_NOT_FOUND));
 		if (chatParticipant.isHost()) {
+			chatMessageRepository.deleteAllByChatRoom(chatRoom);
 			chatRoomRepository.delete(chatRoom);
 			return;
 		}

--- a/src/main/java/com/project/catxi/common/api/error/ChatParticipantErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/ChatParticipantErrorCode.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum ChatParticipantErrorCode implements ErrorCode{
 
 	PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATPARTICIPANT404", "채팅방 참여자를 찾을 수 없습니다."),
-	ALREADY_IN_ACTIVE_ROOM(HttpStatus.CONFLICT,"CHATPARTICIPANT409","이미 참여 중인 채팅방이 있습니다.");
+	ALREADY_IN_ROOM(HttpStatus.CONFLICT,"CHATPARTICIPANT409","이미 참여 중인 채팅방이 있습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #47 

## 📝작업 내용
chatparticipant 객체 잔류 문제로 인하여 unique 제약조건과 active 필드 제거하기로 했습니다.
채팅방을 나갈 경우 hard delete 처리하고, 채팅방 입장 및 생성 시에 서비스 단에서 검사합니다

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?