### PR TITLE
[FEAT] 신고하기 api 구현

### DIFF
--- a/src/main/java/com/project/catxi/common/api/error/ReportErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/ReportErrorCode.java
@@ -1,0 +1,18 @@
+package com.project.catxi.common.api.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportErrorCode implements ErrorCode {
+    SELF_REPORT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "REPORT402", "자기 자신을 신고할 수 없습니다."),
+    NOT_A_CHAT_PARTICIPANT(HttpStatus.FORBIDDEN, "REPORT403", "채팅방 참여자만 신고할 수 있습니다."),
+    REPORTED_MEMBER_NOT_IN_ROOM(HttpStatus.BAD_REQUEST, "REPORT404", "신고 대상이 해당 채팅방에 없습니다."),
+    ALREADY_REPORTED(HttpStatus.CONFLICT, "REPORT409", "해당 사용자에 대한 신고가 이미 접수되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/catxi/common/api/handler/ReportExceptionHandler.java
+++ b/src/main/java/com/project/catxi/common/api/handler/ReportExceptionHandler.java
@@ -1,0 +1,10 @@
+package com.project.catxi.common.api.handler;
+
+import com.project.catxi.common.api.error.ErrorCode;
+import com.project.catxi.common.api.exception.CatxiException;
+
+public class ReportExceptionHandler extends CatxiException {
+    public ReportExceptionHandler(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/catxi/report/config/ReportConfig.java
+++ b/src/main/java/com/project/catxi/report/config/ReportConfig.java
@@ -1,0 +1,14 @@
+package com.project.catxi.report.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class ReportConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/project/catxi/report/controller/ReportController.java
+++ b/src/main/java/com/project/catxi/report/controller/ReportController.java
@@ -1,0 +1,35 @@
+package com.project.catxi.report.controller;
+
+import com.project.catxi.common.api.ApiResponse;
+import com.project.catxi.member.DTO.CustomUserDetails;
+import com.project.catxi.report.dto.ReportCreateReq;
+import com.project.catxi.report.dto.ReportCreateRes;
+import com.project.catxi.report.service.ReportService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping()
+public class ReportController {
+
+    private final ReportService reportService;
+
+    public ReportController(ReportService reportService) {
+        this.reportService = reportService;
+    }
+
+    @PostMapping("/rooms/{roomId}/report/{targetUserId}")
+    public ResponseEntity<ApiResponse<ReportCreateRes>> reportUser(
+            @PathVariable Long roomId,
+            @PathVariable Long targetUserId,
+            @Valid @RequestBody ReportCreateReq request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        String reporterMembername = userDetails.getUsername();
+        ReportCreateRes response = reportService.createReport(roomId, targetUserId, reporterMembername, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
+    }
+}

--- a/src/main/java/com/project/catxi/report/domain/Report.java
+++ b/src/main/java/com/project/catxi/report/domain/Report.java
@@ -1,0 +1,37 @@
+package com.project.catxi.report.domain;
+
+import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.common.domain.BaseTimeEntity;
+import com.project.catxi.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Report extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", referencedColumnName = "roomId")
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reporter_id")
+    private Member reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reported_member_id")
+    private Member reportedMember;
+
+    @Column(nullable = false, length = 500)
+    private String reason;
+}

--- a/src/main/java/com/project/catxi/report/dto/ReportCreateReq.java
+++ b/src/main/java/com/project/catxi/report/dto/ReportCreateReq.java
@@ -1,0 +1,10 @@
+package com.project.catxi.report.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ReportCreateReq(
+        @NotBlank(message = "신고 사유는 필수입니다.")
+        @Size(min = 10, max = 500, message = "신고 사유는 10자 이상 500자 이하로 입력해야 합니다.")
+        String reason
+) {}

--- a/src/main/java/com/project/catxi/report/dto/ReportCreateRes.java
+++ b/src/main/java/com/project/catxi/report/dto/ReportCreateRes.java
@@ -1,0 +1,22 @@
+package com.project.catxi.report.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.project.catxi.report.domain.Report;
+import java.time.LocalDateTime;
+
+public record ReportCreateRes(
+        Long reportId,
+        Long reportedUserId,
+        String reportedUserNickname,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime reportedAt
+) {
+    public static ReportCreateRes from(Report report) {
+        return new ReportCreateRes(
+                report.getId(),
+                report.getReportedMember().getId(),
+                report.getReportedMember().getNickname(),
+                report.getCreatedTime()
+        );
+    }
+}

--- a/src/main/java/com/project/catxi/report/repository/ReportRepository.java
+++ b/src/main/java/com/project/catxi/report/repository/ReportRepository.java
@@ -1,0 +1,14 @@
+package com.project.catxi.report.repository;
+
+import com.project.catxi.report.domain.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    @Query("SELECT r FROM Report r WHERE r.chatRoom.roomId = :roomId AND r.reporter.id = :reporterId AND r.reportedMember.id = :reportedMemberId")
+    Optional<Report> findDuplicateReport(@Param("roomId") Long roomId, @Param("reporterId") Long reporterId, @Param("reportedMemberId") Long reportedMemberId);
+}

--- a/src/main/java/com/project/catxi/report/service/DiscordWebhookService.java
+++ b/src/main/java/com/project/catxi/report/service/DiscordWebhookService.java
@@ -1,0 +1,76 @@
+package com.project.catxi.report.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.catxi.report.domain.Report;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class DiscordWebhookService {
+
+    @Value("${discord.webhook.url:}")
+    private String webhookUrl;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void sendReportNotification(Report report) {
+        if (webhookUrl == null || webhookUrl.isEmpty()) {
+            log.warn("Discord webhook URL이 설정되지 않아 알림을 전송하지 않습니다.");
+            return;
+        }
+        try {
+            String payload = createPayload(report);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<String> entity = new HttpEntity<>(payload, headers);
+            restTemplate.postForEntity(webhookUrl, entity, String.class);
+            log.info("Discord 신고 알림 전송 성공. Report ID: {}", report.getId());
+        } catch (Exception e) {
+            log.error("Discord 웹훅 전송 실패. Report ID: {}. Error: {}", report.getId(), e.getMessage());
+        }
+    }
+
+    private String createPayload(Report report) throws Exception {
+        String content = String.format("""
+                        🚨 **새로운 신고 접수** 🚨
+                        ```
+                        신고 ID      : %d
+                        채팅방 ID    : %d
+                        
+                        --- 신고자 정보 ---
+                        이름 (닉네임)  : %s (%s)
+                        학번         : %d
+                        
+                        --- 피신고자 정보 ---
+                        이름 (닉네임)  : %s (%s)
+                        학번         : %d
+                        
+                        --- 신고 내용 ---
+                        사유         : %s
+                        접수 시각    : %s
+                        ```""",
+                report.getId(),
+                report.getChatRoom().getRoomId(),
+                report.getReporter().getMembername(),
+                report.getReporter().getNickname(),
+                report.getReporter().getStudentNo(),
+                report.getReportedMember().getMembername(),
+                report.getReportedMember().getNickname(),
+                report.getReportedMember().getStudentNo(),
+                report.getReason(),
+                report.getCreatedTime()
+        );
+        return objectMapper.writeValueAsString(new DiscordWebhookPayload(content));
+    }
+
+    private record DiscordWebhookPayload(String content) {
+    }
+}

--- a/src/main/java/com/project/catxi/report/service/ReportService.java
+++ b/src/main/java/com/project/catxi/report/service/ReportService.java
@@ -1,0 +1,74 @@
+package com.project.catxi.report.service;
+
+import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.chat.repository.ChatParticipantRepository;
+import com.project.catxi.chat.repository.ChatRoomRepository;
+import com.project.catxi.common.api.error.CommonErrorCode;
+import com.project.catxi.common.api.error.ReportErrorCode;
+import com.project.catxi.common.api.handler.ReportExceptionHandler;
+import com.project.catxi.member.domain.Member;
+import com.project.catxi.member.repository.MemberRepository;
+import com.project.catxi.report.domain.Report;
+import com.project.catxi.report.dto.ReportCreateReq;
+import com.project.catxi.report.dto.ReportCreateRes;
+import com.project.catxi.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final MemberRepository memberRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatParticipantRepository chatParticipantRepository;
+    private final DiscordWebhookService discordWebhookService;
+
+    @Transactional
+    public ReportCreateRes createReport(Long roomId, Long targetUserId, String reporterMembername, ReportCreateReq req) {
+        Member reporter = memberRepository.findByMembername(reporterMembername)
+                .orElseThrow(() -> new ReportExceptionHandler(CommonErrorCode.USER_NOT_FOUND));
+
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new ReportExceptionHandler(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        Member reportedMember = memberRepository.findById(targetUserId)
+                .orElseThrow(() -> new ReportExceptionHandler(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        validateReport(chatRoom, reporter, reportedMember);
+
+        Report report = Report.builder()
+                .chatRoom(chatRoom)
+                .reporter(reporter)
+                .reportedMember(reportedMember)
+                .reason(req.reason())
+                .build();
+
+        Report savedReport = reportRepository.save(report);
+
+        discordWebhookService.sendReportNotification(savedReport);
+
+        return ReportCreateRes.from(savedReport);
+    }
+
+    private void validateReport(ChatRoom room, Member reporter, Member reportedMember) {
+        if (reporter.getId().equals(reportedMember.getId())) {
+            throw new ReportExceptionHandler(ReportErrorCode.SELF_REPORT_NOT_ALLOWED);
+        }
+
+        if (!chatParticipantRepository.existsByChatRoomAndMember(room, reporter)) {
+            throw new ReportExceptionHandler(ReportErrorCode.NOT_A_CHAT_PARTICIPANT);
+        }
+
+        if (!chatParticipantRepository.existsByChatRoomAndMember(room, reportedMember)) {
+            throw new ReportExceptionHandler(ReportErrorCode.REPORTED_MEMBER_NOT_IN_ROOM);
+        }
+
+        reportRepository.findDuplicateReport(room.getRoomId(), reporter.getId(), reportedMember.getId())
+                .ifPresent(report -> {
+                    throw new ReportExceptionHandler(ReportErrorCode.ALREADY_REPORTED);
+                });
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -36,3 +36,7 @@ spring:
 server:
   port: 8080
 
+discord:
+  webhook:
+    url: ${DISCORD_WEBHOOK_URL:}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,7 @@ spring:
 
 server:
   port: 8080
+
+discord:
+  webhook:
+    url: ${DISCORD_WEBHOOK_URL:}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #39 

## 📝작업 내용

> **채팅방 내 사용자 신고 기능 구현**

> 채팅방에서 부적절한 행동을 하는 사용자를 신고할 수 있는 기능을 구현했습니다. 신고 시 Discord 웹훅을 통해 관리자에게 실시간 알림이 전송되며, 다양한 검증 로직을 통해 악용을 방지합니다.

### 주요 구현 사항

**🏗️ 백엔드 구조**
- `report` 패키지로 신고 기능 분리 구성
- Report 엔티티 및 Repository 구현
- ReportService에 비즈니스 로직 구현
- Discord 웹훅 연동을 위한 DiscordWebhookService 구현

**✅ 검증 로직**
- 자기 자신 신고 방지
- 채팅방 참여자만 신고 가능
- 동일 채팅방에서 동일 사용자에 대한 중복 신고 방지
- 신고 사유 길이 검증 (10자 이상 500자 이하)

**📡 API 구현**
- `POST /rooms/{roomId}/report/{targetUserId}` 엔드포인트
- RESTful한 URL 설계로 신고 대상을 Path Parameter로 처리
- Request Body에는 신고 사유만 포함하여 간소화

**🔔 관리자 알림**
- Discord 웹훅을 통한 실시간 신고 접수 알림
- 신고자/피신고자 정보, 신고 사유, 채팅방 정보 포함
- 웹훅 전송 실패 시에도 신고 접수는 정상 처리