### PR TITLE
Fix/#59/chatroomres localdatetime

### DIFF
--- a/src/main/java/com/project/catxi/chat/controller/ChatController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ChatController.java
@@ -61,7 +61,14 @@ public class ChatController {
 		return ResponseEntity.ok(ApiResponse.success(history));
 	}
 
-	@Operation(summary = "채팅방 목록 조회", description = "역 방향, 정류장, 정렬 기준, 페이지 정보를 기반으로 채팅방 목록을 조회합니다.")
+	@Operation(summary = "채팅방 목록 조회", description = "역 방향, 정류장, 정렬 기준, 페이지 정보를 기반으로 채팅방 목록을 조회합니다."
+			+ """
+			한 페이지에 최대 10개의 채팅방이 포함됩니다.
+			- direction: 'FROM_SCHOOL' 또는 'TO_SCHOOL' 중 하나를 선택합니다.
+			- station: 'SOSA_ST' 또는 'YEOKGOK_ST' 또는 'ETC' 중 하나를 선택합니다.
+			- sort: 'departAt' 또는 'createdTime' 중 하나를 선택합니다.
+			- page: 페이지 번호 (기본값은 0입니다).
+			""")
 	@GetMapping("/rooms")
 	public ResponseEntity<ApiResponse<CommonPageResponse<ChatRoomRes>>> getRoomList(
 		@RequestParam("direction") String direction,

--- a/src/main/java/com/project/catxi/chat/dto/ChatRoomRes.java
+++ b/src/main/java/com/project/catxi/chat/dto/ChatRoomRes.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.project.catxi.chat.domain.ChatRoom;
 import com.project.catxi.common.domain.Location;
 import com.project.catxi.common.domain.RoomStatus;
@@ -18,9 +19,9 @@ public record ChatRoomRes (
 	Long recruitSize,
 	Long currentSize,
 	RoomStatus status,
-	@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
 	LocalDateTime departAt,
-	@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
 	LocalDateTime createdTime
 ){
 	public static ChatRoomRes from (ChatRoom chatRoom){

--- a/src/main/java/com/project/catxi/chat/dto/ChatRoomRes.java
+++ b/src/main/java/com/project/catxi/chat/dto/ChatRoomRes.java
@@ -1,5 +1,9 @@
 package com.project.catxi.chat.dto;
 
+import java.time.LocalDateTime;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
 import com.project.catxi.chat.domain.ChatRoom;
 import com.project.catxi.common.domain.Location;
 import com.project.catxi.common.domain.RoomStatus;
@@ -14,8 +18,10 @@ public record ChatRoomRes (
 	Long recruitSize,
 	Long currentSize,
 	RoomStatus status,
-	String departAt,
-	String createdTime
+	@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	LocalDateTime departAt,
+	@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	LocalDateTime createdTime
 ){
 	public static ChatRoomRes from (ChatRoom chatRoom){
 		return new ChatRoomRes(
@@ -28,8 +34,8 @@ public record ChatRoomRes (
 			chatRoom.getMaxCapacity(),
 			(long)chatRoom.getParticipants().size(),
 			chatRoom.getStatus(),
-			chatRoom.getDepartAt().toString(),
-			chatRoom.getCreatedTime().toString()
+			chatRoom.getDepartAt(),
+			chatRoom.getCreatedTime()
 		);
 	}
 }

--- a/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatRoomRepositoryCustomImpl.java
@@ -56,8 +56,8 @@ public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom {
 				chatRoom.maxCapacity,
 				participant.id.countDistinct(),
 				chatRoom.status,
-				chatRoom.departAt.stringValue(),
-				chatRoom.createdTime.stringValue()
+				chatRoom.departAt,
+				chatRoom.createdTime
 			))
 			.from(chatRoom)
 			.join(chatRoom.host, host)

--- a/src/main/java/com/project/catxi/common/domain/RoomStatus.java
+++ b/src/main/java/com/project/catxi/common/domain/RoomStatus.java
@@ -1,5 +1,5 @@
 package com.project.catxi.common.domain;
 
 public enum RoomStatus {
-	WAITING, READY_CHECK, READY_LOCKED, MATCHED, EXPIRED
+	WAITING, READY_LOCKED, MATCHED, EXPIRED
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #59 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
채팅방 목록 조회시 반환되는 채팅방 정보 필드 형식 변경
- departAt: String -> LocalDateTime  (yyyy-MM-dd'T'HH:mm:ss)
- createdTime: String -> LocalDateTime (yyyy-MM-dd'T'HH:mm:ss)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?