### PR TITLE
[FEAT] 최초 로그인 유저 구분 및 회원가입

### DIFF
--- a/src/main/java/com/project/catxi/common/auth/controller/OAuthController.java
+++ b/src/main/java/com/project/catxi/common/auth/controller/OAuthController.java
@@ -6,12 +6,14 @@ import com.project.catxi.common.api.exception.CatxiException;
 import com.project.catxi.common.auth.kakao.KakaoDTO;
 import com.project.catxi.common.auth.service.CustomOAuth2UserService;
 import com.project.catxi.common.auth.service.CustomUserDetailsService;
+import com.project.catxi.common.domain.MemberStatus;
 import com.project.catxi.member.domain.Member;
 import com.project.catxi.member.dto.CustomUserDetails;
 import com.project.catxi.member.repository.MemberRepository;
 import com.project.catxi.member.service.MemberService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
@@ -43,13 +45,18 @@ public class OAuthController {
     }
 
     try {
-      customOAuth2UserService.oAuthLogin(accessCode, response);
-      return ApiResponse.success("로그인 성공");
+      Member user = customOAuth2UserService.oAuthLogin(accessCode, response);
+
+      if (user.getStatus() == MemberStatus.PENDING) {
+        return ApiResponse.success("isNewUser");
+      } else {
+        return ApiResponse.success("로그인 성공");
+      }
     } catch (Exception e) {
       log.error("[카카오 로그인 실패] code = {}, error = {}", accessCode, e.getMessage());
       // 실패한 경우 usedCodes에서 제거 (재시도 가능하게)
       usedCodes.remove(accessCode);
-      return ApiResponse.error(MemberErrorCode.ACCESS_EXPIRED); // 또는 적절한 에러 코드
+      return ApiResponse.error(MemberErrorCode.ACCESS_EXPIRED);
     }
   }
 

--- a/src/main/java/com/project/catxi/common/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/project/catxi/common/auth/service/CustomOAuth2UserService.java
@@ -6,6 +6,7 @@ import com.project.catxi.common.auth.kakao.KakaoDTO;
 import com.project.catxi.common.auth.kakao.KakaoUtill;
 import com.project.catxi.common.config.JwtConfig;
 import com.project.catxi.common.config.WebConfig;
+import com.project.catxi.common.domain.MemberStatus;
 import com.project.catxi.common.jwt.JwtUtill;
 import com.project.catxi.member.domain.Member;
 import com.project.catxi.member.repository.MemberRepository;
@@ -41,6 +42,10 @@ public class CustomOAuth2UserService {
     // JWT 발급 후 응답 헤더에 추가
     String jwt = loginProcess(response, user);
 
+    // /signUp/catxi로 분기
+    boolean isNewUser = user.getStatus()==MemberStatus.ACTIVE;
+    response.setHeader("isNewUser", String.valueOf(isNewUser));
+
     log.info("[카카오 프로필] email = {}", requestEmail);
     log.info("✅JWT 발급 : {}", jwt);
 
@@ -65,6 +70,7 @@ public class CustomOAuth2UserService {
         .password("NO_PASSWORD")
         .matchCount(0)
         .role("ROLE_USER")
+        .status(MemberStatus.PENDING)
         .build();
 
     return memberRepository.save(newUser);
@@ -97,6 +103,7 @@ public class CustomOAuth2UserService {
 
     member.setNickname(dto.nickname());
     member.setStudentNo(dto.StudentNo());
+    member.setStatus(MemberStatus.ACTIVE);
   }
 
 

--- a/src/main/java/com/project/catxi/common/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/project/catxi/common/auth/service/CustomOAuth2UserService.java
@@ -43,7 +43,7 @@ public class CustomOAuth2UserService {
     String jwt = loginProcess(response, user);
 
     // /signUp/catxi로 분기
-    boolean isNewUser = user.getStatus()==MemberStatus.ACTIVE;
+    boolean isNewUser = user.getStatus()==MemberStatus.PENDING;
     response.setHeader("isNewUser", String.valueOf(isNewUser));
 
     log.info("[카카오 프로필] email = {}", requestEmail);

--- a/src/main/java/com/project/catxi/common/config/SecurityConfig.java
+++ b/src/main/java/com/project/catxi/common/config/SecurityConfig.java
@@ -101,7 +101,7 @@ public class SecurityConfig {
     configuration.setAllowedOrigins(List.of("http://localhost:5173","https://catxi.kro.kr"));
 
     configuration.addAllowedHeader("*");
-    configuration.setExposedHeaders(List.of("access", "Authorization"));
+    configuration.setExposedHeaders(List.of("access", "Authorization","isNewUser"));
 
     configuration.addAllowedMethod("*");
 

--- a/src/main/java/com/project/catxi/common/domain/MemberStatus.java
+++ b/src/main/java/com/project/catxi/common/domain/MemberStatus.java
@@ -1,0 +1,5 @@
+package com.project.catxi.common.domain;
+
+public enum MemberStatus {
+  PENDING,ACTIVE,INACTIVE
+}

--- a/src/main/java/com/project/catxi/member/domain/Member.java
+++ b/src/main/java/com/project/catxi/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.project.catxi.member.domain;
 
+import com.project.catxi.common.domain.MemberStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -47,6 +48,9 @@ public class Member extends BaseTimeEntity {
 	@Column(nullable = false)
 	private boolean isLogin;
 
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private MemberStatus status;
 
 	// 로그인했음 표시
 	//public void setLogin(boolean isLogin) {this.isLogin = isLogin;}


### PR DESCRIPTION
## #️⃣연관된 이슈

#62 

## 📝작업 내용

유저 로그인 시 최초 로그인 여부를 판단합니다
헤더에 isNewUser 추가하여 들고, 캣시 내부 회원가입으로 이동시킵니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?