### PR TITLE
[FIX] 닉네임 중복 조회 수정

### DIFF
--- a/src/main/java/com/project/catxi/common/auth/controller/OAuthController.java
+++ b/src/main/java/com/project/catxi/common/auth/controller/OAuthController.java
@@ -12,6 +12,7 @@ import com.project.catxi.member.dto.CustomUserDetails;
 import com.project.catxi.member.repository.MemberRepository;
 import com.project.catxi.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.Map;
@@ -73,10 +74,9 @@ public class OAuthController {
 
   @Operation(summary = "닉네임 중복 조회")
   @GetMapping("/signUp/catxi/checkNN")
-  public ResponseEntity<?> checkNN(@RequestParam String nickname) {
-  boolean isDuplicate = customOAuth2UserService.isNNDuplicate(nickname);
-
-    return ResponseEntity.ok("닉네임 사용 가능");
+  public ResponseEntity<?> checkNN(@RequestParam("nickname") String nickname) {
+    boolean isDuplicate = customOAuth2UserService.isNNDuplicate(nickname);
+    return ResponseEntity.ok(isDuplicate);
   }
 
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #77

## 📝작업 내용

> 파라미터 명시적 선언으로 닉네임을 받아와 중복 조회를 boolean 값으로 반환시켰습니다.

> 파라미터를 읽지 못하던 오류 수정했습니다.
