### PR TITLE
[FEAT] ReadyService 기능 구현

### DIFF
--- a/src/main/java/com/project/catxi/chat/config/ReadyMessageEventListener.java
+++ b/src/main/java/com/project/catxi/chat/config/ReadyMessageEventListener.java
@@ -1,0 +1,35 @@
+package com.project.catxi.chat.config;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.project.catxi.chat.dto.ReadyMessageEvent;
+import com.project.catxi.chat.service.RedisPubSubService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+public class ReadyMessageEventListener {
+
+	private final RedisPubSubService redisPubSubService;
+	private final ObjectMapper objectMapper;
+
+	// ObjectMapper 초기 설정을 생성자에서 해도 됩니다.
+	public ReadyMessageEventListener(RedisPubSubService redisPubSubService, ObjectMapper objectMapper) {
+		this.redisPubSubService = redisPubSubService;
+		this.objectMapper = objectMapper;
+		this.objectMapper.registerModule(new JavaTimeModule());
+		this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void onReadyMessageEvent(ReadyMessageEvent event) throws JsonProcessingException {
+			String json = objectMapper.writeValueAsString(event.readyMessageRes());
+			redisPubSubService.publish(event.channel(), json);
+	}
+}

--- a/src/main/java/com/project/catxi/chat/config/StompHandler.java
+++ b/src/main/java/com/project/catxi/chat/config/StompHandler.java
@@ -64,8 +64,9 @@ public class StompHandler implements ChannelInterceptor {
 				throw new AuthenticationServiceException("destination 파싱 오류");
 			}
 
+			String roomIdStr = parts[parts.length - 1];
 			try {
-				Long roomId = Long.parseLong(parts[2]);
+				Long roomId = Long.parseLong(roomIdStr);
 				log.info("Room ID: {}", roomId);
 				if (!chatRoomService.isRoomParticipant(email, roomId)) {
 					log.warn("Room 참가자 아님: {} not in room {}", email, roomId);

--- a/src/main/java/com/project/catxi/chat/controller/ReadyController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ReadyController.java
@@ -1,0 +1,54 @@
+package com.project.catxi.chat.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.catxi.chat.service.ChatRoomService;
+import com.project.catxi.chat.service.ReadyService;
+import com.project.catxi.common.api.ApiResponse;
+
+import com.project.catxi.member.dto.CustomUserDetails;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ready")
+public class ReadyController {
+	private final ChatRoomService chatRoomService;
+	private final ReadyService readyService;
+
+
+	// 클라이언트로부터 메시지를 받아 해당 채팅방에 있는 모든 클라이언트에게 전송하는 엔드포인트
+	@PostMapping("/request/{roomId}")
+	public ResponseEntity<ApiResponse<Void>> sendMessage(@PathVariable String roomId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		readyService.requestReady(roomId, userDetails.getUsername());
+
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
+	// 클라이언트로부터 메시지를 받아 해당 채팅방의 방장에게 전송하는 엔드포인트
+	@PostMapping("/accept/{roomId}")
+	public ResponseEntity<ApiResponse<Void>> sendMessageToHost(@PathVariable String roomId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		readyService.acceptReady(roomId, userDetails.getUsername());
+
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
+	@PostMapping("/reject/{roomId}")
+	public ResponseEntity<ApiResponse<Void>> rejectReady(@PathVariable String roomId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		readyService.rejectReady(roomId, userDetails.getUsername());
+		chatRoomService.leaveChatRoom(Long.valueOf(roomId), userDetails.getUsername());
+
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
+
+}

--- a/src/main/java/com/project/catxi/chat/controller/ReadyController.java
+++ b/src/main/java/com/project/catxi/chat/controller/ReadyController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.project.catxi.chat.service.ChatRoomService;
 import com.project.catxi.chat.service.ReadyService;
 import com.project.catxi.common.api.ApiResponse;
@@ -25,8 +26,8 @@ public class ReadyController {
 
 	// 클라이언트로부터 메시지를 받아 해당 채팅방에 있는 모든 클라이언트에게 전송하는 엔드포인트
 	@PostMapping("/request/{roomId}")
-	public ResponseEntity<ApiResponse<Void>> sendMessage(@PathVariable String roomId,
-		@AuthenticationPrincipal CustomUserDetails userDetails) {
+	public ResponseEntity<ApiResponse<Void>> sendMessage(@PathVariable Long roomId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) throws JsonProcessingException {
 		readyService.requestReady(roomId, userDetails.getUsername());
 
 		return ResponseEntity.ok(ApiResponse.successWithNoData());
@@ -34,18 +35,18 @@ public class ReadyController {
 
 	// 클라이언트로부터 메시지를 받아 해당 채팅방의 방장에게 전송하는 엔드포인트
 	@PostMapping("/accept/{roomId}")
-	public ResponseEntity<ApiResponse<Void>> sendMessageToHost(@PathVariable String roomId,
-		@AuthenticationPrincipal CustomUserDetails userDetails) {
+	public ResponseEntity<ApiResponse<Void>> sendMessageToHost(@PathVariable Long roomId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) throws JsonProcessingException {
 		readyService.acceptReady(roomId, userDetails.getUsername());
 
 		return ResponseEntity.ok(ApiResponse.successWithNoData());
 	}
 
 	@PostMapping("/reject/{roomId}")
-	public ResponseEntity<ApiResponse<Void>> rejectReady(@PathVariable String roomId,
-		@AuthenticationPrincipal CustomUserDetails userDetails) {
+	public ResponseEntity<ApiResponse<Void>> rejectReady(@PathVariable Long roomId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) throws JsonProcessingException {
 		readyService.rejectReady(roomId, userDetails.getUsername());
-		chatRoomService.leaveChatRoom(Long.valueOf(roomId), userDetails.getUsername());
+		chatRoomService.leaveChatRoom(roomId, userDetails.getUsername());
 
 		return ResponseEntity.ok(ApiResponse.successWithNoData());
 	}

--- a/src/main/java/com/project/catxi/chat/domain/ChatRoom.java
+++ b/src/main/java/com/project/catxi/chat/domain/ChatRoom.java
@@ -40,6 +40,7 @@ public class ChatRoom extends BaseTimeEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
+	@Setter
 	private RoomStatus status;
 
 	@Column(nullable = false)

--- a/src/main/java/com/project/catxi/chat/dto/ReadyMessageEvent.java
+++ b/src/main/java/com/project/catxi/chat/dto/ReadyMessageEvent.java
@@ -1,0 +1,3 @@
+package com.project.catxi.chat.dto;
+
+public record ReadyMessageEvent(String channel, ReadyMessageRes readyMessageRes) { }

--- a/src/main/java/com/project/catxi/chat/dto/ReadyMessageRes.java
+++ b/src/main/java/com/project/catxi/chat/dto/ReadyMessageRes.java
@@ -1,0 +1,53 @@
+package com.project.catxi.chat.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.project.catxi.common.domain.ReadyType;
+import com.project.catxi.member.domain.Member;
+
+public record ReadyMessageRes(
+	ReadyType type, // ex) "READY_REQUEST", "READY_ACCEPT", ...
+	Long roomId,
+	Long senderId,
+	String senderEmail,
+	String senderName,
+	String content, // ex) "준비 상태로 변경되었습니다."
+	LocalDateTime sentAt // ex) "2023-10-01T12:00:00"
+) {
+	public static ReadyMessageRes readyRequest(Long roomId, Member sender) {
+		return new ReadyMessageRes(
+			ReadyType.READY_REQUEST,
+			roomId,
+			sender.getId(),
+			sender.getEmail(),
+			sender.getMembername(),
+			"방장이 Ready 요청을 보냈습니다",
+			LocalDateTime.now()
+		);
+	}
+
+	public static ReadyMessageRes readyAccept(Long roomId, Member sender) {
+		return new ReadyMessageRes(
+			ReadyType.READY_ACCEPT,
+			roomId,
+			sender.getId(),
+			sender.getEmail(),
+			sender.getMembername(),
+			"참여자가 Ready를 수락했습니다",
+			LocalDateTime.now()
+		);
+	}
+
+	public static ReadyMessageRes readyDeny(Long roomId, Member sender) {
+		return new ReadyMessageRes(
+			ReadyType.READY_DENY,
+			roomId,
+			sender.getId(),
+			sender.getEmail(),
+			sender.getMembername(),
+			"참여자가 Ready를 거절했습니다",
+			LocalDateTime.now()
+		);
+	}
+}

--- a/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.project.catxi.chat.domain.ChatMessage;
 import com.project.catxi.chat.domain.ChatParticipant;
@@ -24,7 +27,15 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 
 	long countByChatRoom(ChatRoom room);
 
+	long countByChatRoomAndIsReady(ChatRoom chatRoom, boolean ready);
 
 	List<ChatParticipant> findByChatRoom(ChatRoom chatRoom);
 
+	@Modifying(clearAutomatically = true)
+	@Transactional
+	@Query("UPDATE ChatParticipant cp SET cp.isReady = false WHERE cp.chatRoom.roomId = :roomId AND cp.isHost = false")
+	void updateIsReadyFalseExceptHost(Long roomId);
+
+	@Transactional
+	void deleteAllByChatRoomAndIsReadyFalse(ChatRoom chatroom);
 }

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -164,6 +164,15 @@ public class ChatRoomService {
 
 	}
 
+	public boolean isHost(Long roomId, String email){
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
+		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+		return chatRoom.getHost().equals(member);
+	}
+
+
 	public boolean isRoomParticipant(String email, Long roomId) {
 		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new EntityNotFoundException("room not found"));
@@ -177,6 +186,18 @@ public class ChatRoomService {
 		}
 		return false;
 
+	}
+
+	public void checkRoomEnter(Long roomId, String email) {
+		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+		if(!isRoomParticipant(email, roomId)){
+			throw new CatxiException(ChatParticipantErrorCode.PARTICIPANT_NOT_FOUND);
+		}
+
+		if((chatRoom.getStatus()== RoomStatus.READY_LOCKED) && !isRoomParticipant(email, roomId)){
+			throw new CatxiException(ChatRoomErrorCode.CHATROOM_READY_LOCKED);
+		}
 	}
 
 

--- a/src/main/java/com/project/catxi/chat/service/ReadyService.java
+++ b/src/main/java/com/project/catxi/chat/service/ReadyService.java
@@ -34,11 +34,9 @@ public class ReadyService {
 	private final MemberRepository memberRepository;
 	private final ChatRoomRepository chatRoomRepository;
 	private final TimerService timerService;
-	private final RedisPubSubService redisPubSubService;
-	private final ObjectMapper objectMapper;
 
 	@Transactional
-	public void requestReady(Long roomId, String email) throws JsonProcessingException {
+	public void requestReady(Long roomId, String email){
 		ChatRoom room = chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
@@ -71,7 +69,7 @@ public class ReadyService {
 	}
 
 	@Transactional
-	public void acceptReady(Long roomId, String email) throws JsonProcessingException {
+	public void acceptReady(Long roomId, String email) {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
@@ -91,7 +89,7 @@ public class ReadyService {
 	}
 
 	@Transactional
-	public void rejectReady(Long roomId, String email) throws JsonProcessingException {
+	public void rejectReady(Long roomId, String email) {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
 

--- a/src/main/java/com/project/catxi/chat/service/ReadyService.java
+++ b/src/main/java/com/project/catxi/chat/service/ReadyService.java
@@ -1,0 +1,140 @@
+package com.project.catxi.chat.service;
+
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.catxi.chat.domain.ChatParticipant;
+import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.chat.repository.ChatParticipantRepository;
+import com.project.catxi.chat.repository.ChatRoomRepository;
+import com.project.catxi.common.api.error.ChatParticipantErrorCode;
+import com.project.catxi.common.api.error.ChatRoomErrorCode;
+import com.project.catxi.common.api.error.MemberErrorCode;
+import com.project.catxi.common.api.exception.CatxiException;
+import com.project.catxi.common.domain.RoomStatus;
+import com.project.catxi.member.domain.Member;
+import com.project.catxi.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReadyService {
+	private final ChatParticipantRepository chatParticipantRepository;
+	private final MemberRepository memberRepository;
+	private final ChatRoomRepository chatRoomRepository;
+	private final TimerService timerService;
+	private final SseService sseService;
+	private final SseSubscriber sseSubscriber;
+
+	@Transactional
+	public void requestReady(String roomId, String email) {
+		ChatRoom room = chatRoomRepository.findById(Long.valueOf(roomId))
+			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		ChatParticipant participant = chatParticipantRepository.findByChatRoomAndMember(room, member)
+			.orElseThrow(() -> new CatxiException(ChatParticipantErrorCode.PARTICIPANT_NOT_FOUND));
+
+		if (!participant.isHost()) {
+			throw new CatxiException(ChatRoomErrorCode.NOT_OWNED_CHATROOM);
+		}
+
+		if (!room.getStatus().equals(RoomStatus.WAITING)) {
+			throw new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_WAITING);
+		}
+
+		room.setStatus(RoomStatus.READY_LOCKED);
+		SseSendReq payload = new SseSendReq(
+			"READY REQUEST",
+			"방장이 Ready 요청을 보냈습니다",
+			roomId,
+			member.getMembername(),
+			"CLIENT"
+		);
+		sseSubscriber.publish("sse:" + roomId, payload); // publish 호출
+
+		/*
+		레디 요청 10초 이후 (레디 요청 당시의 참여자 수 == 10초 이후 참여자 수)가
+			- True라면 MATCHED로 변경
+			- False라면 WAITING으로 변경
+		*/
+
+		timerService.scheduleReadyTimeout(roomId);
+
+
+	}
+
+	@Transactional
+	public void acceptReady(String roomId, String email) {
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		ChatRoom room = chatRoomRepository.findById(Long.valueOf(roomId))
+			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		ChatParticipant participant = chatParticipantRepository.findByChatRoomAndMember(room, member)
+			.orElseThrow(() -> new CatxiException(ChatParticipantErrorCode.PARTICIPANT_NOT_FOUND));
+
+		checkParticipant(room,participant);
+
+		participant.setReady(true);
+		SseSendReq payload = new SseSendReq(
+			"READY ACCEPT",
+			"참여자가 Ready를 수락했습니다",
+			roomId,
+			member.getMembername(),
+			"HOST"
+		);
+		sseSubscriber.publish("sse:" + roomId, payload);
+
+	}
+
+	@Transactional
+	public void rejectReady(String roomId, String email) {
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		ChatRoom room = chatRoomRepository.findById(Long.valueOf(roomId))
+			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		ChatParticipant participant = chatParticipantRepository.findByChatRoomAndMember(room, member)
+			.orElseThrow(() -> new CatxiException(ChatParticipantErrorCode.PARTICIPANT_NOT_FOUND));
+
+		checkParticipant(room,participant);
+
+		SseSendReq payload = new SseSendReq(
+			"READY REJECT",
+			"참여자가 Ready를 거절했습니다",
+			roomId,
+			member.getMembername(),
+			"HOST"
+		);
+
+		/*
+		 * 방장에게 Ready 거절 메시지 전송
+		 * sse 연결 해제
+		 */
+		sseSubscriber.publish("sse:" + roomId, payload);
+		sseService.disconnect(roomId, email, false);
+
+	}
+
+	private void checkParticipant(ChatRoom room, ChatParticipant participant) {
+		if(!room.getStatus().equals(RoomStatus.READY_LOCKED)) {
+			throw new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_READY_LOCKED);
+		}
+		if(participant.isHost()) {
+			throw new CatxiException(ChatRoomErrorCode.INVALID_CHATROOM_PARAMETER);
+		}
+
+		if (participant.isReady()) {
+			throw new CatxiException(ChatParticipantErrorCode.ALREADY_READY);
+		}
+	}
+
+
+}

--- a/src/main/java/com/project/catxi/chat/service/TimerService.java
+++ b/src/main/java/com/project/catxi/chat/service/TimerService.java
@@ -1,0 +1,89 @@
+package com.project.catxi.chat.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.concurrent.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.chat.repository.ChatParticipantRepository;
+import com.project.catxi.chat.repository.ChatRoomRepository;
+import com.project.catxi.common.api.error.ChatRoomErrorCode;
+import com.project.catxi.common.api.exception.CatxiException;
+import com.project.catxi.common.domain.RoomStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TimerService {
+
+	private static final Logger log = LoggerFactory.getLogger(TimerService.class);
+	private final RedisTemplate<String, String> redisTemplate;
+	private final TaskScheduler taskScheduler;
+	private final ChatRoomRepository chatRoomRepository;
+	private final ChatParticipantRepository chatParticipantRepository;
+
+	public void scheduleReadyTimeout(String roomId) {
+		ChatRoom room = chatRoomRepository.findById(Long.valueOf(roomId))
+			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		long participantCount = chatParticipantRepository.countByChatRoom(room);
+
+		// Redis에 당시 참여자 수 저장
+		redisTemplate.opsForValue().set("ready:" + roomId, String.valueOf(participantCount), Duration.ofSeconds(25));
+
+		// TaskScheduler로 10초 뒤 작업 예약
+		taskScheduler.schedule(() -> {
+				try {
+					checkAndUpdateRoomStatus(roomId);
+				} catch (Exception e) {
+					log.error("Error checking and updating room status for roomId: {}", roomId, e);
+				}
+			},
+			Instant.now().plusSeconds(20)
+		);
+	}
+
+	@Transactional
+	public void checkAndUpdateRoomStatus(String roomId) {
+		ChatRoom room = chatRoomRepository.findById(Long.valueOf(roomId))
+			.orElseThrow(() -> new CatxiException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		String savedCountStr = redisTemplate.opsForValue().get("ready:" + roomId);
+
+		if (room.getStatus() != RoomStatus.READY_LOCKED) {
+			return;
+		}
+
+		if (savedCountStr == null) {
+			// Redis 키가 사라졌거나 문제가 생긴 경우
+			chatParticipantRepository.updateIsReadyFalseExceptHost(room.getRoomId());
+			room.setStatus(RoomStatus.WAITING);
+		} else {
+			long savedCount = Long.parseLong(savedCountStr);
+			long currentCount = chatParticipantRepository.countByChatRoomAndIsReady(room, true);
+
+			if (savedCount == currentCount) {
+				room.matchedStatus(RoomStatus.MATCHED);
+			} else {
+				chatParticipantRepository.deleteAllByChatRoomAndIsReadyFalse(room);
+				chatParticipantRepository.updateIsReadyFalseExceptHost(room.getRoomId());
+				room.setStatus(RoomStatus.WAITING);
+			}
+		}
+
+		chatRoomRepository.save(room);
+		redisTemplate.delete("ready:" + roomId);
+	}
+
+
+}

--- a/src/main/java/com/project/catxi/common/api/error/ChatParticipantErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/ChatParticipantErrorCode.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChatParticipantErrorCode implements ErrorCode{
 
+	ALREADY_READY(HttpStatus.BAD_REQUEST, "CHATPARTICIPANT400", "이미 준비 상태입니다."),
 	PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATPARTICIPANT404", "채팅방 참여자를 찾을 수 없습니다."),
 	ALREADY_IN_ROOM(HttpStatus.CONFLICT,"CHATPARTICIPANT409","이미 참여 중인 채팅방이 있습니다.");
 

--- a/src/main/java/com/project/catxi/common/api/error/ChatRoomErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/ChatRoomErrorCode.java
@@ -9,6 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChatRoomErrorCode implements ErrorCode{
 
+	CHATROOM_READY_LOCKED(HttpStatus.BAD_REQUEST, "CHATROOM400", "채팅방이 준비 요청 상태 입니다."),
+	CHATROOM_NOT_READY_LOCKED(HttpStatus.BAD_REQUEST, "CHATROOM400", "채팅방이 준비 요청 상태가 아닙니다."),
+	CHATROOM_NOT_WAITING(HttpStatus.BAD_REQUEST, "CHATROOM400", "채팅방이 대기 상태가 아닙니다."),
 	CHATROOM_NOT_MATCHED(HttpStatus.NOT_FOUND, "CHATROOM404", "채팅방이 매칭 상태가 아닙니다."),
 	CHATROOM_FULL(HttpStatus.NOT_FOUND, "CHATROOM405", "채팅방에 인원이 꽉찼습니다."),
 	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM404", "채팅방를 찾을 수 없습니다."),

--- a/src/main/java/com/project/catxi/common/config/RedisConfig.java
+++ b/src/main/java/com/project/catxi/common/config/RedisConfig.java
@@ -57,6 +57,7 @@ public class RedisConfig {
 		RedisMessageListenerContainer container=new RedisMessageListenerContainer();
 		container.setConnectionFactory(redisConnectionFactory);
 		container.addMessageListener(messageListenerAdapter, new PatternTopic("chat"));
+		container.addMessageListener(messageListenerAdapter, new PatternTopic("ready:*"));
 		return container;
 	}
 

--- a/src/main/java/com/project/catxi/common/domain/ReadyType.java
+++ b/src/main/java/com/project/catxi/common/domain/ReadyType.java
@@ -1,0 +1,7 @@
+package com.project.catxi.common.domain;
+
+public enum ReadyType {
+	READY_REQUEST, // 준비 요청
+	READY_ACCEPT,  // 준비 수락
+	READY_DENY     // 준비 거절
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #86 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- /topic/ready/{roomId}로 토픽 구독
- ready:{roomId}로 redis 채널 구독
- 일반 RESTApi 호출하면 내부에서 트랜잭션 commit 이후 Ready 관련 메시지 발행
- StompHandler 두 줄 수정
  - 기존 코드는 `/topic/[   ]/..`  의 두번째 요소를 roomId로 가져와서 검사하므로 해당 토픽 구독 불가 처리됨
  - /topic/.../[  ] 의 마지막 요소를 roomId로 가져와서 검사하도록 수정


### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/4ab94912-17d4-4e9e-b885-4051cdd4bd5c)

로컬에서 8080 8081 포트 열고 통신했을 때 보이는 값

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?