### PR TITLE
[FIX] matchedAt 할당 조건 READY_LOCKED로 변경

### DIFF
--- a/src/main/java/com/project/catxi/chat/domain/ChatRoom.java
+++ b/src/main/java/com/project/catxi/chat/domain/ChatRoom.java
@@ -56,7 +56,7 @@ public class ChatRoom extends BaseTimeEntity {
 	//matched된 시점 기록
 	//matched되었다 다시 waiting으로 되돌아갈 수 있는가?
 	public void matchedStatus(RoomStatus newStatus) {
-		if (status == RoomStatus.MATCHED && this.matchedAt == null) {
+		if (status == RoomStatus.READY_LOCKED && this.matchedAt == null) {
 			this.matchedAt = LocalDateTime.now();
 		}
 		this.status = newStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #88 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

방 상태가 READY_LOCKED 에서 MATCHED로 넘어갈 때 ChatRoom의 matchedAt 필드가 할당되어야 해서 수정했습니다.
변경 사항 적용되면 MATCHED 상태로 업데이트 될 때 당시 시각이 matchedAt 필드에 할당되고,
이후 MATCHED 방 상태에서 방장이 채팅방 삭제 API를 호출하면 매칭 내역에 기록됩니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?