### PR TITLE
[FIX] CHATROOM_FULL 조건에 +1 추가

### DIFF
--- a/src/main/java/com/project/catxi/CatxiApplication.java
+++ b/src/main/java/com/project/catxi/CatxiApplication.java
@@ -1,21 +1,13 @@
 package com.project.catxi;
 
-import java.util.TimeZone;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-import jakarta.annotation.PostConstruct;
 
 @SpringBootApplication
 @EnableScheduling
 public class CatxiApplication {
-
-	@PostConstruct
-	public void started() {
-		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(CatxiApplication.class, args);

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -124,7 +124,7 @@ public class ChatRoomService {
 			throw new CatxiException(ChatRoomErrorCode.INVALID_CHATROOM_PARAMETER);
 
 		long current = chatParticipantRepository.countByChatRoom(chatRoom);
-		if (current >= chatRoom.getMaxCapacity())
+		if (current >= chatRoom.getMaxCapacity() + 1)
 			throw new CatxiException(ChatRoomErrorCode.CHATROOM_FULL);
 
 		ChatParticipant chatParticipant = ChatParticipant.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #100 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

maxCapacity에는 방장이 포함 안 되어 있어서 방장을 제외한 현재 참가 인원이 모집 인원보다 한 명 적을 때도 CHATROOM_FULL이 뜨는 오류

- ex) 모집인원 1명으로 방 생성 -> 방장 혼자 있어도 방이 다 찬 걸로 인식


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?