### PR TITLE
[FIX] 시스템 메시지 NPE 및 참여자 갱신 브로드캐스트, Jackson 전역 설정 통일 & 중복 제거

### DIFF
--- a/src/main/java/com/project/catxi/chat/config/JacksonConfig.java
+++ b/src/main/java/com/project/catxi/chat/config/JacksonConfig.java
@@ -1,0 +1,22 @@
+package com.project.catxi.chat.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class JacksonConfig {
+
+	@Bean
+	@Primary
+	public ObjectMapper objectMapper(){
+		ObjectMapper om= new ObjectMapper();
+		om.registerModule(new JavaTimeModule());
+		om.disable(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS);
+		return om;
+	}
+}

--- a/src/main/java/com/project/catxi/chat/config/JacksonConfig.java
+++ b/src/main/java/com/project/catxi/chat/config/JacksonConfig.java
@@ -16,7 +16,7 @@ public class JacksonConfig {
 	public ObjectMapper objectMapper(){
 		ObjectMapper om= new ObjectMapper();
 		om.registerModule(new JavaTimeModule());
-		om.disable(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS);
+		om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 		return om;
 	}
 }

--- a/src/main/java/com/project/catxi/chat/config/ReadyMessageEventListener.java
+++ b/src/main/java/com/project/catxi/chat/config/ReadyMessageEventListener.java
@@ -14,18 +14,12 @@ import com.project.catxi.chat.service.RedisPubSubService;
 import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class ReadyMessageEventListener {
 
 	private final RedisPubSubService redisPubSubService;
 	private final ObjectMapper objectMapper;
 
-	// ObjectMapper 초기 설정을 생성자에서 해도 됩니다.
-	public ReadyMessageEventListener(RedisPubSubService redisPubSubService, ObjectMapper objectMapper) {
-		this.redisPubSubService = redisPubSubService;
-		this.objectMapper = objectMapper;
-		this.objectMapper.registerModule(new JavaTimeModule());
-		this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void onReadyMessageEvent(ReadyMessageEvent event) throws JsonProcessingException {

--- a/src/main/java/com/project/catxi/chat/config/RedisPubSubConfig.java
+++ b/src/main/java/com/project/catxi/chat/config/RedisPubSubConfig.java
@@ -1,0 +1,62 @@
+package com.project.catxi.chat.config;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import com.project.catxi.chat.service.RedisPubSubService;
+
+@Configuration
+public class RedisPubSubConfig {
+
+	@Bean
+	public RedisMessageListenerContainer redisMessageListenerContainer(
+		RedisConnectionFactory connectionFactory,
+		RedisPubSubService listener,
+		ThreadPoolTaskScheduler redisPubSubScheduler
+	) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		container.setTaskExecutor(redisPubSubScheduler); // 수신 스레드풀
+
+		// 채널 구독: 정확히 "chat" 채널
+		container.addMessageListener(listener, new ChannelTopic("chat"));
+
+		// 패턴 구독: ready:*, participants:*, kick:* 모두 수신
+		container.addMessageListener(listener, new PatternTopic("ready:*"));
+		container.addMessageListener(listener, new PatternTopic("participants:*"));
+		container.addMessageListener(listener, new PatternTopic("kick:*"));
+
+		return container;
+	}
+
+	// 2) 리스너 스레드풀(권장)
+	@Bean
+	public ThreadPoolTaskScheduler redisPubSubScheduler() {
+		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+		scheduler.setPoolSize(4);
+		scheduler.setThreadNamePrefix("redis-pubsub-");
+		scheduler.initialize();
+		return scheduler;
+	}
+
+	@Bean
+	@Qualifier("chatPubSub")
+	public StringRedisTemplate chatPubSubTemplate(RedisConnectionFactory cf) {
+		StringRedisTemplate tpl = new StringRedisTemplate(cf);
+		var s = new org.springframework.data.redis.serializer.StringRedisSerializer(StandardCharsets.UTF_8);
+		tpl.setKeySerializer(s);
+		tpl.setValueSerializer(s);
+		tpl.setHashKeySerializer(s);
+		tpl.setHashValueSerializer(s);
+		return tpl;
+	}
+}

--- a/src/main/java/com/project/catxi/chat/controller/StompController.java
+++ b/src/main/java/com/project/catxi/chat/controller/StompController.java
@@ -24,19 +24,20 @@ public class StompController {
 	private final SimpMessageSendingOperations messageTemplate;
 	private final ChatMessageService chatMessageService;
 	private final RedisPubSubService pubSubService;
+	private final ObjectMapper objectMapper;
 
 	public StompController(SimpMessageSendingOperations messageTemplate, ChatMessageService chatMessageService,
-		RedisPubSubService pubSubService) {
+		RedisPubSubService pubSubService,ObjectMapper objectMapper) {
 		this.messageTemplate = messageTemplate;
 		this.chatMessageService = chatMessageService;
 		this.pubSubService = pubSubService;
+		this.objectMapper=objectMapper;
 	}
 
 
 
 	@MessageMapping("/{roomId}")
 	public void sendMessage(@DestinationVariable Long roomId, ChatMessageSendReq chatMessageSendReq) throws JsonProcessingException {
-		System.out.println(chatMessageSendReq.message());
 		chatMessageService.saveMessage(roomId, chatMessageSendReq);
 		//messageTemplate.convertAndSend("/topic/"+ roomId,chatMessageSendReq);
 
@@ -46,9 +47,6 @@ public class StompController {
 			chatMessageSendReq.message(),
 			LocalDateTime.now()
 		);
-		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.registerModule(new JavaTimeModule());
-		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 		String message = objectMapper.writeValueAsString(enriched);
 		pubSubService.publish("chat", message);
 	}

--- a/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
@@ -38,6 +38,7 @@ public class ChatMessageService {
 	private final ChatMessageRepository chatMessageRepository;
 	private final ChatParticipantRepository chatParticipantRepository;
 	private final RedisPubSubService pubSubService;
+	private final ObjectMapper objectMapper;
 
 	public void saveMessage(Long roomId,ChatMessageSendReq req) {
 		ChatRoom room = chatRoomRepository.findById(roomId)
@@ -104,11 +105,7 @@ public class ChatMessageService {
 		);
 
 		try {
-			String json = new ObjectMapper()
-				.registerModule(new JavaTimeModule())
-				.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-				.writeValueAsString(dto);
-
+			String json = objectMapper.writeValueAsString(dto);
 			pubSubService.publish("chat", json);
 		} catch (JsonProcessingException e) {
 			throw new RuntimeException("시스템 메시지 직렬화 실패", e);

--- a/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
@@ -71,7 +71,7 @@ public class ChatMessageService {
 		return chatMessageRepository.findByChatRoomOrderByCreatedTimeAsc(room)
 			.stream()
 			.map(m -> new ChatMessageRes(
-				m.getMember().getEmail(),
+				m.getMember() !=null ? m.getMember().getEmail(): "[SYSTEM]",
 				m.getId(),
 				room.getRoomId(),
 				m.getMember().getId(),

--- a/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
@@ -75,8 +75,8 @@ public class ChatMessageService {
 				m.getMember() !=null ? m.getMember().getEmail(): "[SYSTEM]",
 				m.getId(),
 				room.getRoomId(),
-				m.getMember().getId(),
-				m.getMember().getNickname(),
+				m.getMember() != null ? m.getMember().getId()        : null,
+				m.getMember() != null ? m.getMember().getNickname()  : "[SYSTEM]",
 				m.getContent(),
 				m.getCreatedTime()
 			))

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -63,8 +63,6 @@ public class ChatRoomService {
 	private final KickedParticipantRepository kickedParticipantRepository;
 
 	private final ChatMessageService chatMessageService;
-	private final StringRedisTemplate stringRedisTemplate;
-
 
 
 	public RoomCreateRes createRoom(RoomCreateReq roomReq, String email) {
@@ -134,6 +132,7 @@ public class ChatRoomService {
 
 		chatParticipantRepository.delete(chatParticipant);
 
+		sendParticipantUpdateMessage(chatRoom);
 
 		String systemMessage = member.getNickname() + " 님이 퇴장하셨습니다.";
 		chatMessageService.sendSystemMessage(roomId, systemMessage);
@@ -166,6 +165,7 @@ public class ChatRoomService {
 
 		chatParticipantRepository.save(chatParticipant);
 
+		sendParticipantUpdateMessage(chatRoom);
 
 		chatMessageService.sendSystemMessage(roomId, member.getNickname() + " 님이 입장하셨습니다.");
 	}
@@ -199,13 +199,13 @@ public class ChatRoomService {
 
 		chatParticipantRepository.delete(participant);
 
-
-
 		KickedParticipant kicked = KickedParticipant.builder()
 			.chatRoom(room)
 			.member(target)
 			.build();
 		kickedParticipantRepository.save(kicked);
+
+		sendParticipantUpdateMessage(room);
 
 		String msg = target.getNickname() + " 님이 강퇴되었습니다.";
 		chatMessageService.sendSystemMessage(roomId, msg);
@@ -215,7 +215,6 @@ public class ChatRoomService {
 
 
 	}
-
 
 
 	private void HostNotInOtherRoom(Member host) {

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -52,13 +52,9 @@ public class ChatRoomService {
 	private final ChatParticipantRepository chatParticipantRepository;
 	private final MemberRepository memberRepository;
 	private final ChatMessageRepository chatMessageRepository;
-
+	private final ObjectMapper objectMapper;
 
 	private final StringRedisTemplate stringRedisTemplate;
-
-	private final ObjectMapper objectMapper = new ObjectMapper()
-		.registerModule(new JavaTimeModule())
-		.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
 	private final KickedParticipantRepository kickedParticipantRepository;
 

--- a/src/main/java/com/project/catxi/common/auth/googongchill.java
+++ b/src/main/java/com/project/catxi/common/auth/googongchill.java
@@ -1,0 +1,5 @@
+package com.project.catxi.common.auth;
+
+public class googongchill {
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#121 
## 📝작업 내용
### Jackson 전역 설정 통일 & 중복 제거
    - 전역 `ObjectMapper`에 `JavaTimeModule` 등록 및 `WRITE_DATES_AS_TIMESTAMPS` 비활성화
    - `ReadyMessageEventListener`에서 중복 설정 제거
    - 목적: 날짜 포맷 일관화(ISO-8601), 성능/유지보수성 향상

### Redis Pub/Sub 채널 라우팅 안정화
    - `onMessage()`에서 `message.getChannel()`+UTF-8 사용
    - `RedisMessageListenerContainer`에 `chat`, `ready:*`, `participants:*`, `kick:*` 구독 등록
    - 목적: 채널/패턴 혼용 시 라우팅 오류 제거

### 시스템 메시지 NPE 및 참여자 갱신 브로드캐스트
    - `getChatHistory()`에서 `member == null` 가드 추가
    - 입장/퇴장/강퇴 후 `participants:{roomId}` 발행 이미 반영 확인
    - 목적: 시스템 메시지 조회 안정화, UI 동기화 개선

### 정렬 파라미터 화이트리스트
    - `departAt`/`createdTime`만 허용
    - 목적: 예외/잠재 보안 이슈 방지

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?