### PR TITLE
[FIX] WebSocket 권한 검증 보강

### DIFF
--- a/src/main/java/com/project/catxi/chat/config/StompHandler.java
+++ b/src/main/java/com/project/catxi/chat/config/StompHandler.java
@@ -1,13 +1,13 @@
 
 package com.project.catxi.chat.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 
 
@@ -28,7 +28,6 @@ public class StompHandler implements ChannelInterceptor {
 	private final JwtUtill jwtUtill;
 	private final ChatRoomService chatRoomService;
 
-
 	@Override
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
 		final StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
@@ -38,52 +37,79 @@ public class StompHandler implements ChannelInterceptor {
 			try {
 				Claims claims = jwtUtill.parseJwt(token);
 				jwtUtill.isExpired(claims);
-				System.out.println("CONNECT - 토큰 유효성 검증 완료");
+				log.info("CONNECT - 토큰 유효성 검증 완료");
+
+				String email = jwtUtill.getEmail(claims);
+				accessor.setUser(new UsernamePasswordAuthenticationToken(email, null, java.util.Collections.emptyList()));
+				log.info("CONNECT - 토큰 유효성 검증 및 Principal 설정 완료: {}", email);
+
 			} catch (Exception e) {
 				throw new MemberHandler(MemberErrorCode.ACCESS_EXPIRED);
 			}
 		}
 
 		if (StompCommand.SUBSCRIBE == accessor.getCommand()) {
-			log.info("SUBSCRIBE 진입");
-			log.info("Authorization Header: {}", accessor.getFirstNativeHeader("Authorization"));
-			log.info("Destination: {}", accessor.getDestination());
-
-			String token = extractToken(accessor);
-			Claims claims;
-			String email;
-			log.info("Email from token: {}", jwtUtill.getEmail(jwtUtill.parseJwt(token)));
-
-			String destination = accessor.getDestination();
-			if (destination == null || !destination.startsWith("/topic/")) {
-				log.error("잘못된 destination: {}", destination);
-				throw new AuthenticationServiceException("잘못된 destination입니다.");
+			final String dest = accessor.getDestination();
+			if (dest == null) {
+				throw new AuthenticationServiceException("destination 누락");
 			}
 
-			String[] parts = destination.split("/");
-			if (parts.length < 3) {
-				log.error("destination split 오류: {}", (Object) parts);
-				throw new AuthenticationServiceException("destination 파싱 오류");
+			// 1) 개인 큐는 통과 (사용자 본인만 받음)
+			if (dest.startsWith("/user/queue/")) {
+				return message;
 			}
 
-			String roomIdStr = parts[parts.length - 1];
-			try {
-				claims = jwtUtill.parseJwt(token);
-				email = jwtUtill.getEmail(claims);
-				Long roomId = Long.parseLong(roomIdStr);
-				log.info("Room ID: {}", roomId);
-				if (!chatRoomService.isRoomParticipant(email, roomId)) {
-					log.warn("Room 참가자 아님: {} not in room {}", email, roomId);
-					throw new AuthenticationServiceException("해당 room에 권한이 없습니다");
-				}
-			} catch (NumberFormatException e) {
-				log.error("roomId가 숫자 아님: {}", parts[2]);
-				throw new AuthenticationServiceException("roomId가 숫자가 아님");
+			// 2) topic 계열만 방 권한 검사
+			if (!dest.startsWith("/topic/")) {
+				throw new AuthenticationServiceException("지원하지 않는 destination: " + dest);
 			}
+
+			// 인증 주체(email) 결정: Principal 우선, 없으면 JWT 재파싱
+			final String email = resolveEmail(accessor);
+
+			// 3) destination 어디에 있든 roomId(숫자 세그먼트)를 찾아서 권한 검사
+			Long roomId = extractNumericSegment(dest);
+			if (roomId == null) {
+				throw new AuthenticationServiceException("destination에서 roomId를 찾을 수 없습니다: " + dest);
+			}
+
+			if (!chatRoomService.isRoomParticipant(email, roomId)) {
+				log.warn("SUBSCRIBE 권한 없음: email={}, roomId={}, dest={}", email, roomId, dest);
+				throw new AuthenticationServiceException("해당 room에 권한이 없습니다");
+			}
+
+			log.info("SUBSCRIBE 허용: email={}, roomId={}, dest={}", email, roomId, dest);
 		}
 
 		return message;
 	}
+
+	private String resolveEmail(StompHeaderAccessor accessor) {
+		// 1) Principal 우선
+		if (accessor.getUser() != null && accessor.getUser().getName() != null) {
+			return accessor.getUser().getName();
+		}
+		// 2) SUBSCRIBE 헤더로 온 JWT (프론트가 매 프레임 Authorization을 넣는 경우)
+		String bearerToken = accessor.getFirstNativeHeader("Authorization");
+		if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+			Claims claims = jwtUtill.parseJwt(bearerToken.substring(7).trim());
+			return jwtUtill.getEmail(claims);
+		}
+		// 3) 둘 다 없으면 인증정보 없음
+		throw new AuthenticationServiceException("인증 정보가 없습니다(Principal/Authorization)");
+	}
+
+	private Long extractNumericSegment(String dest) {
+		String[] segs = dest.split("/");
+		for (int i = segs.length - 1; i >= 0; i--) {
+			String seg = segs[i];
+			if (!seg.isEmpty() && seg.chars().allMatch(Character::isDigit)) {
+				try { return Long.valueOf(seg); } catch (NumberFormatException ignored) {}
+			}
+		}
+		return null;
+	}
+
 
 	private String extractToken(StompHeaderAccessor accessor) {
 		String bearerToken = accessor.getFirstNativeHeader("Authorization");
@@ -92,6 +118,5 @@ public class StompHandler implements ChannelInterceptor {
 		}
 		return bearerToken.substring(7).trim();
 	}
-
-
 }
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> #123

## 📝작업 내용
- SUBSCRIBE: `/user/queue/*` 허용, destination에서 숫자 roomId 추출 후 참가자 검증
-  `@MessageMapping`에서 `Principal`로 이메일 덮어쓰기
- 목적: 스푸핑 방지, 큐/참여자 채널 호환성 확보

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?