### PR TITLE
[FIX] 방 삭제시 해당 방인원 실시간 나가지는 기능으로 변경

### DIFF
--- a/src/main/java/com/project/catxi/chat/config/RoomDeletedEventListener.java
+++ b/src/main/java/com/project/catxi/chat/config/RoomDeletedEventListener.java
@@ -1,0 +1,35 @@
+package com.project.catxi.chat.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.catxi.chat.dto.RoomDeletedEvent;
+import com.project.catxi.chat.dto.RoomEventMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RoomDeletedEventListener {
+
+	private final @Qualifier("chatPubSub") StringRedisTemplate redis;
+	private final ObjectMapper objectMapper;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void on(RoomDeletedEvent e) {
+		try {
+			String json = objectMapper.writeValueAsString(
+				new RoomEventMessage(e.roomId(), "DELETED", e.hostNickname() + " 님이 방을 삭제했습니다.")
+			);
+			// 방 단위 브로드캐스트
+			redis.convertAndSend("roomdeleted:" + e.roomId(), json);
+
+		} catch (Exception ex) {
+			throw new RuntimeException("RoomDeletedEvent publish failed", ex);
+		}
+	}
+}

--- a/src/main/java/com/project/catxi/chat/dto/RoomDeletedEvent.java
+++ b/src/main/java/com/project/catxi/chat/dto/RoomDeletedEvent.java
@@ -1,0 +1,6 @@
+package com.project.catxi.chat.dto;
+
+import java.util.List;
+
+public record RoomDeletedEvent(Long roomId, List<String> emails, String hostNickname) {}
+

--- a/src/main/java/com/project/catxi/chat/dto/RoomEventMessage.java
+++ b/src/main/java/com/project/catxi/chat/dto/RoomEventMessage.java
@@ -1,0 +1,4 @@
+package com.project.catxi.chat.dto;
+
+public record RoomEventMessage(Long roomId, String type, String message) {}
+

--- a/src/main/java/com/project/catxi/chat/service/RedisPubSubService.java
+++ b/src/main/java/com/project/catxi/chat/service/RedisPubSubService.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.project.catxi.chat.dto.ChatMessageSendReq;
 import com.project.catxi.chat.dto.ParticipantsUpdateMessage;
 import com.project.catxi.chat.dto.ReadyMessageRes;
+import com.project.catxi.chat.dto.RoomEventMessage;
 import com.project.catxi.map.dto.CoordinateRes;
 
 @Service
@@ -55,6 +56,9 @@ public class RedisPubSubService implements MessageListener {
 			} else if (channel.startsWith("kick:")) {
 				String email = channel.split(":",2)[1];
 				messageTemplate.convertAndSendToUser(email, "/queue/kick", "KICKED");
+			} else if (channel.startsWith("roomdeleted:")) {
+				RoomEventMessage evt = objectMapper.readValue(payload, RoomEventMessage.class);
+				messageTemplate.convertAndSend("/topic/room/" + evt.roomId() + "/deleted", evt);
 			}
 		} catch (JsonProcessingException e) {
 			throw new RuntimeException(e);

--- a/src/main/java/com/project/catxi/common/config/RedisConfig.java
+++ b/src/main/java/com/project/catxi/common/config/RedisConfig.java
@@ -91,6 +91,7 @@ public class RedisConfig {
 		container.addMessageListener(listener, new PatternTopic("ready:*"));
 		container.addMessageListener(listener, new PatternTopic("participants:*"));
 		container.addMessageListener(listener, new PatternTopic("kick:*"));
+		container.addMessageListener(listener, new PatternTopic("roomdeleted:*"));
 		return container;
 	}
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #147 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
방장이 방 삭제 시 참여자 화면에 즉시 반영되지 않아 기존 방에 남아있는 문제가 발생.

### 해결방안
도메인 이벤트: RoomDeletedEvent(roomId, emails, hostNickname) 추가
AFTER_COMMIT 브로드캐스트: RoomDeletedEventListener에서 커밋 후
Redis 채널 roomdeleted:{roomId}로 {"roomId", "type":"DELETED", "message":...} 전송
STOMP 브릿지: RedisPubSubService에 분기 추가
roomdeleted:* → /topic/room/{roomId}/deleted로 전송

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?