### PR TITLE
[FEAT] Ready 요청 결과에 실시간 메시지 전송

### DIFF
--- a/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/project/catxi/chat/repository/ChatParticipantRepository.java
@@ -39,6 +39,9 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
     @Transactional
     void deleteAllByChatRoomAndIsReadyFalse(ChatRoom chatroom);
 
+    @Query("SELECT cp.member.nickname FROM ChatParticipant cp WHERE cp.chatRoom = :chatRoom AND cp.isReady = false")
+    List<String> findNickNameByChatRoomAndIsReadyFalse(ChatRoom chatRoom);
+
     Optional<ChatParticipant> findByMember(Member member);
 
     @Query("SELECT cp.member.email FROM ChatParticipant cp WHERE cp.chatRoom = :chatRoom")

--- a/src/main/java/com/project/catxi/chat/service/RedisPubSubService.java
+++ b/src/main/java/com/project/catxi/chat/service/RedisPubSubService.java
@@ -59,6 +59,9 @@ public class RedisPubSubService implements MessageListener {
 			} else if (channel.startsWith("roomdeleted:")) {
 				RoomEventMessage evt = objectMapper.readValue(payload, RoomEventMessage.class);
 				messageTemplate.convertAndSend("/topic/room/" + evt.roomId() + "/deleted", evt);
+			} else if(channel.startsWith("readyresult:")){
+				RoomEventMessage evt = objectMapper.readValue(payload, RoomEventMessage.class);
+				messageTemplate.convertAndSend("/topic/ready/" + evt.roomId() + "/result", evt);
 			}
 		} catch (JsonProcessingException e) {
 			throw new RuntimeException(e);

--- a/src/main/java/com/project/catxi/chat/service/TimerService.java
+++ b/src/main/java/com/project/catxi/chat/service/TimerService.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.*;
 
 import org.slf4j.Logger;
@@ -14,7 +15,9 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.catxi.chat.domain.ChatRoom;
+import com.project.catxi.chat.dto.RoomEventMessage;
 import com.project.catxi.chat.repository.ChatParticipantRepository;
 import com.project.catxi.chat.repository.ChatRoomRepository;
 import com.project.catxi.common.api.error.ChatRoomErrorCode;
@@ -22,27 +25,33 @@ import com.project.catxi.common.api.exception.CatxiException;
 import com.project.catxi.common.domain.RoomStatus;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 public class TimerService {
 
-	private static final Logger log = LoggerFactory.getLogger(TimerService.class);
-
+	private final ObjectMapper objectMapper;
 	private final RedisTemplate<String, String> redisTemplate;
 	private final TaskScheduler taskScheduler;
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatParticipantRepository chatParticipantRepository;
+	private final ChatMessageService chatMessageService;
 
 	public TimerService(
 		RedisTemplate<String, String> redisTemplate,
 		@Qualifier("commonTaskScheduler") TaskScheduler taskScheduler,
 		ChatRoomRepository chatRoomRepository,
-		ChatParticipantRepository chatParticipantRepository
+		ChatParticipantRepository chatParticipantRepository,
+		ChatMessageService chatMessageService,
+		ObjectMapper objectMapper
 	) {
 		this.redisTemplate = redisTemplate;
 		this.taskScheduler = taskScheduler;
 		this.chatRoomRepository = chatRoomRepository;
 		this.chatParticipantRepository = chatParticipantRepository;
+		this.chatMessageService = chatMessageService;
+		this.objectMapper = objectMapper;
 	}
 
 	public void scheduleReadyTimeout(String roomId) {
@@ -84,19 +93,43 @@ public class TimerService {
 		} else {
 			long savedCount = Long.parseLong(savedCountStr);
 			long currentCount = chatParticipantRepository.countByChatRoomAndIsReady(room, true);
+			Long roomIdLong = Long.valueOf(roomId);
 
 			if (savedCount == currentCount) {
 				room.matchedStatus(RoomStatus.MATCHED);
+				publishRoomResult(roomIdLong, "MATCHED", "모든 참가자가 준비되었습니다. 매칭이 완료되었습니다");
 			} else {
+				// 준비하지 않은 참가자 퇴장 메시지 전송
+				List<String> removeNickNames = chatParticipantRepository.findNickNameByChatRoomAndIsReadyFalse(room);
+
+				// DB에서 준비하지 않은 참가자 삭제
 				chatParticipantRepository.deleteAllByChatRoomAndIsReadyFalse(room);
 				chatParticipantRepository.updateIsReadyFalseExceptHost(room.getRoomId());
+
+				for (String nickName : removeNickNames) {
+					String systemMessage = nickName + " 님이 퇴장하셨습니다.";
+					chatMessageService.sendSystemMessage(roomIdLong, systemMessage);
+				}
+
 				room.setStatus(RoomStatus.WAITING);
+				publishRoomResult(roomIdLong, "RETURN_WAITING", "일부 참가자가 준비하지 않아 대기 상태로 돌아갑니다.");
 			}
 		}
 
 		chatRoomRepository.save(room);
 		redisTemplate.delete("ready:" + roomId);
+
+		log.info("[TimerService] 방 상태 업데이트 완료: {} at {}", roomId, LocalDateTime.now());
 	}
 
 
+	private void publishRoomResult(Long roomId, String type, String content) {
+		try {
+			RoomEventMessage evt = new RoomEventMessage(roomId, type, content);
+			String json = objectMapper.writeValueAsString(evt);
+			redisTemplate.convertAndSend("readyresult:" + roomId, json);
+		} catch (Exception e) {
+			log.error("Failed to publish room status event for roomId: {}", roomId, e);
+		}
+	}
 }

--- a/src/main/java/com/project/catxi/common/config/RedisConfig.java
+++ b/src/main/java/com/project/catxi/common/config/RedisConfig.java
@@ -92,6 +92,7 @@ public class RedisConfig {
 		container.addMessageListener(listener, new PatternTopic("participants:*"));
 		container.addMessageListener(listener, new PatternTopic("kick:*"));
 		container.addMessageListener(listener, new PatternTopic("roomdeleted:*"));
+		container.addMessageListener(listener, new PatternTopic("readyresult:*"));
 		return container;
 	}
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #154 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- `/topic/ready/{roomId}/result` 채널 추가
- redisConfig `readyresult:` 패턴 토픽 추가
- TimerService 처리 시 방 상태 변화에 따라 소켓 메시지 전송
  - 매칭 성공 시 `/topic/ready/{roomId}/result`로 매칭 완료 메시지 전송
  - 매칭 실패 시 `/topic/ready/{roomId}/result`로 매칭 실패 메시지 전송 +
  퇴장 처리 된 사람들에 대하여 ChatMessageService의 sendSystemMessage 시스템 메시지 전송

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?