### PR TITLE
[FIX] 참여자 페이로드에 이메일 추가

### DIFF
--- a/src/main/java/com/project/catxi/chat/dto/ParticipantBrief.java
+++ b/src/main/java/com/project/catxi/chat/dto/ParticipantBrief.java
@@ -1,0 +1,3 @@
+package com.project.catxi.chat.dto;
+
+public record ParticipantBrief(String nickname, String email) {}

--- a/src/main/java/com/project/catxi/chat/dto/ParticipantsUpdateMessage.java
+++ b/src/main/java/com/project/catxi/chat/dto/ParticipantsUpdateMessage.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 public record ParticipantsUpdateMessage(
 	Long roomId,
-	List<String> participantNicknames
+	List<ParticipantBrief> participants
 ) {}

--- a/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatRoomService.java
@@ -6,6 +6,7 @@ import static com.project.catxi.chat.domain.QChatRoom.*;
 
 import java.time.LocalDateTime;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -26,6 +27,7 @@ import com.project.catxi.chat.domain.ChatRoom;
 import com.project.catxi.chat.domain.KickedParticipant;
 import com.project.catxi.chat.dto.ChatRoomInfoRes;
 import com.project.catxi.chat.dto.ChatRoomRes;
+import com.project.catxi.chat.dto.ParticipantBrief;
 import com.project.catxi.chat.dto.ParticipantsUpdateMessage;
 import com.project.catxi.chat.dto.RoomCreateReq;
 import com.project.catxi.chat.dto.RoomCreateRes;
@@ -287,7 +289,16 @@ public class ChatRoomService {
 
 	private void sendParticipantUpdateMessage(ChatRoom chatRoom) {
 		List<String> nicknames = chatParticipantRepository.findParticipantNicknamesByChatRoom(chatRoom);
-		ParticipantsUpdateMessage update = new ParticipantsUpdateMessage(chatRoom.getRoomId(), nicknames);
+		List<String> emails    = chatParticipantRepository.findParticipantEmailsByChatRoom(chatRoom);
+
+		int size = Math.min(nicknames.size(), emails.size());
+		List<ParticipantBrief> participants = new ArrayList<>(size);
+		for (int i = 0; i < size; i++) {
+			participants.add(new ParticipantBrief(nicknames.get(i), emails.get(i)));
+		}
+
+		ParticipantsUpdateMessage update =
+			new ParticipantsUpdateMessage(chatRoom.getRoomId(), participants);
 
 		try {
 			String json = objectMapper.writeValueAsString(update);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #156 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세

참여자 실시간 정보에 이메일까지 포함하여 프론트가 정확한 사용자 식별/표시를 할 수 있도록 페이로드 확장.
`{
  "roomId": 42,
  "participants": [
    { "nickname": "철수", "email": "chulsoo@example.com" },
    { "nickname": "영희", "email": "younghee@example.com" }
  ]
}`

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?