### PR TITLE
[FIX] 무중단 액세스 토큰 재발급

### DIFF
--- a/src/main/java/com/project/catxi/common/api/error/MemberErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/MemberErrorCode.java
@@ -15,8 +15,8 @@ public enum MemberErrorCode implements ErrorCode{
 	INVALID_STUDENT_NO(HttpStatus.BAD_REQUEST, "MEMBER404", "학번은 9자리 숫자로 입력해주세요"),
 
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"ACCESS400","유효하지 않은 토큰입니다"),
-	ACCESS_EXPIRED(HttpStatus.BAD_REQUEST,"ACCESS401","액세스 토큰이 만료되었습니다"),
-	DUPLICATE_AUTHORIZE_CODE(HttpStatus.BAD_REQUEST,"ACCESS402","인가 코드 중복 사용"),
+	ACCESS_EXPIRED(HttpStatus.UNAUTHORIZED,"ACCESS401","액세스 토큰이 만료되었습니다"),
+	DUPLICATE_AUTHORIZE_CODE(HttpStatus.UNAUTHORIZED,"ACCESS402","인가 코드 중복 사용"),
 	ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN,"ACCESS403","탈퇴한 회원입니다."),
 
 	REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "ACCESS404", "리프레시 토큰이 만료되었습니다."),

--- a/src/main/java/com/project/catxi/common/auth/service/TokenService.java
+++ b/src/main/java/com/project/catxi/common/auth/service/TokenService.java
@@ -171,7 +171,7 @@ public class TokenService {
     }
 
     //무중단 액세스 토큰 재발급 로직
-    public boolean zeroDownRefresh(Claims expiredClaims,
+    public String zeroDownRefresh(Claims expiredClaims,
                                        HttpServletRequest request, 
                                        HttpServletResponse response) {
         try {
@@ -182,7 +182,7 @@ public class TokenService {
             String refreshToken = extractCookie(request, REFRESH_COOKIE);
             if (refreshToken == null) {
                 writeUnauthorized(response, MemberErrorCode.ACCESS_EXPIRED);
-                return false;
+                return null;
             }
 
             // Refresh Token 서명/만료/클레임 검증 + Redis 저장값 일치 확인
@@ -191,7 +191,7 @@ public class TokenService {
 
             if (!valid) {
                 writeUnauthorized(response, MemberErrorCode.REFRESH_TOKEN_MISMATCH);
-                return false;
+                return null;
             }
 
             // 사용자 정보 재확인 (블랙리스트/상태 체크)
@@ -199,7 +199,7 @@ public class TokenService {
             if (member == null || member.getStatus() == MemberStatus.INACTIVE
                 || tokenBlacklistRepository.isUserBlacklisted(member.getId().toString())) {
                 writeForbidden(response, MemberErrorCode.ACCESS_FORBIDDEN);
-                return false;
+                return null;
             }
 
             // 새 Access Token 및 Refresh Token 발급
@@ -218,7 +218,7 @@ public class TokenService {
             exposeHeaders(response, AUTH_HEADER, HEADER_REF);
 
             log.info("✅ AT, RT 재발급 : {}", email);
-            return true;
+            return newAccessToken;
             
         } catch (Exception e) {
             log.error("🚨 액세스토큰 재발급 처리 중 오류: {}", e.getMessage());
@@ -227,7 +227,7 @@ public class TokenService {
             } catch (IOException ioException) {
                 log.error("응답 작성 중 오류: {}", ioException.getMessage());
             }
-            return false;
+            return null;
         }
     }
     

--- a/src/main/java/com/project/catxi/common/auth/service/TokenService.java
+++ b/src/main/java/com/project/catxi/common/auth/service/TokenService.java
@@ -181,7 +181,7 @@ public class TokenService {
             }
 
             Member member = memberRepository.findByEmail(email).orElse(null);
-            if (member == null || member.getStatus() == MemberStatus.INACTIVE) {
+            if (member == null) {
                 return null;
             }
 

--- a/src/main/java/com/project/catxi/common/config/security/JwtFilterConfig.java
+++ b/src/main/java/com/project/catxi/common/config/security/JwtFilterConfig.java
@@ -1,6 +1,7 @@
 package com.project.catxi.common.config.security;
 
 import com.project.catxi.common.auth.infra.TokenBlacklistRepository;
+import com.project.catxi.common.auth.service.TokenService;
 import com.project.catxi.common.jwt.JwtFilter;
 import com.project.catxi.common.jwt.JwtUtil;
 import com.project.catxi.member.repository.MemberRepository;
@@ -12,13 +13,13 @@ import org.springframework.stereotype.Component;
 public class JwtFilterConfig {
 
   private final JwtUtil jwtUtil;
-  private final JwtConfig jwtConfig;
+  private final TokenService tokenService;
   private final MemberRepository memberRepository;
   private final TokenBlacklistRepository tokenBlacklistRepository;
 
-  public JwtFilterConfig(JwtUtil jwtUtil, JwtConfig jwtConfig, MemberRepository memberRepository, TokenBlacklistRepository tokenBlacklistRepository) {
+  public JwtFilterConfig(JwtUtil jwtUtil, TokenService tokenService, MemberRepository memberRepository, TokenBlacklistRepository tokenBlacklistRepository) {
     this.jwtUtil = jwtUtil;
-    this.jwtConfig = jwtConfig;
+    this.tokenService = tokenService;
     this.memberRepository = memberRepository;
     this.tokenBlacklistRepository = tokenBlacklistRepository;
   }
@@ -26,7 +27,7 @@ public class JwtFilterConfig {
   public void configureJwtFilters(HttpSecurity http) throws Exception {
     // JwtFilter - 토큰 검증 및 인증 객체 설정
     http.addFilterBefore(
-        new JwtFilter(jwtUtil, memberRepository, tokenBlacklistRepository), UsernamePasswordAuthenticationFilter.class);
+        new JwtFilter(jwtUtil, tokenService, memberRepository, tokenBlacklistRepository), UsernamePasswordAuthenticationFilter.class);
   }
 
 }

--- a/src/main/java/com/project/catxi/common/jwt/JwtFilter.java
+++ b/src/main/java/com/project/catxi/common/jwt/JwtFilter.java
@@ -3,6 +3,7 @@ package com.project.catxi.common.jwt;
 import com.project.catxi.common.api.error.MemberErrorCode;
 import com.project.catxi.common.api.handler.MemberHandler;
 import com.project.catxi.common.auth.infra.TokenBlacklistRepository;
+import com.project.catxi.common.auth.service.TokenService;
 import com.project.catxi.common.domain.MemberStatus;
 import com.project.catxi.member.dto.CustomUserDetails;
 import com.project.catxi.member.domain.Member;
@@ -26,6 +27,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtFilter extends OncePerRequestFilter {
 
   private final JwtUtil jwtUtil;
+  private final TokenService tokenService;
   private final MemberRepository memberRepository;
   private final TokenBlacklistRepository tokenBlacklistRepository;
 
@@ -41,7 +43,7 @@ public class JwtFilter extends OncePerRequestFilter {
     // JWT 검증 예외 경로
     if (uri.startsWith("/connect") ||
         uri.equals("/auth/login/kakao") ||
-        uri.startsWith("/webjars/**") ||
+        uri.startsWith("/webjars/") ||
         uri.startsWith("/actuator")) {
       filterChain.doFilter(request, response);
       return;
@@ -64,8 +66,19 @@ public class JwtFilter extends OncePerRequestFilter {
     try {
       claims = jwtUtil.parseJwt(accessToken);
     } catch (ExpiredJwtException e) {
-      throw new MemberHandler(MemberErrorCode.ACCESS_EXPIRED);
+      Claims expiredClaims = e.getClaims();
+      if (tokenService.zeroDownRefresh(expiredClaims, request, response)) {
+        // 재발급 성공 시 SecurityContext 설정 후 계속 진행
+        String email = jwtUtil.getEmail(expiredClaims);
+        Member member = memberRepository.findByEmail(email).orElse(null);
+        if (member != null) {
+          setAuthentication(member);
+          filterChain.doFilter(request, response);
+        }
+      }
+      return;
     } catch (Exception e) {
+      // 유효하지 않은 토큰
       throw new MemberHandler(MemberErrorCode.INVALID_TOKEN);
     }
 
@@ -101,16 +114,18 @@ public class JwtFilter extends OncePerRequestFilter {
       throw new MemberHandler(MemberErrorCode.ACCESS_FORBIDDEN);
     }
 
-    // UserDetails에 회원 정보 객체 담기
-    CustomUserDetails customUserDetails = new CustomUserDetails(member);
-
-    // 스프링 시큐리티 인증 토큰 생성
-    Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
-    // 세션에 사용자 등록 (AuthToken 시큐리티 컨텍스트 홀더에 넣어줌)
-    SecurityContextHolder.getContext().setAuthentication(authToken);
-
-    // 그 다음 필터에 request,response 전달
+    // SecurityContext 설정 후 진행
+    setAuthentication(member);
     filterChain.doFilter(request, response);
   }
+
+
+  private void setAuthentication(Member member) {
+    CustomUserDetails customUserDetails = new CustomUserDetails(member);
+    Authentication authToken = new UsernamePasswordAuthenticationToken(
+        customUserDetails, null, customUserDetails.getAuthorities());
+    SecurityContextHolder.getContext().setAuthentication(authToken);
+  }
+
 
 }

--- a/src/main/java/com/project/catxi/common/jwt/JwtUtil.java
+++ b/src/main/java/com/project/catxi/common/jwt/JwtUtil.java
@@ -2,6 +2,7 @@ package com.project.catxi.common.jwt;
 
 import com.project.catxi.common.config.security.JwtConfig;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
@@ -41,9 +42,12 @@ public class JwtUtil {
   }
 
   // 파싱
-  public Claims parseJwt(String token) {
+  public Claims parseJwt(String token) throws ExpiredJwtException {
     try {
       return jwtParser.parseSignedClaims(token).getPayload();
+    } catch (ExpiredJwtException e) {
+      // ExpiredJwtException 예외 X -> zeroDownRefresh 호출되도록
+      throw e;
     } catch (JwtException | IllegalArgumentException e) {
       log.error("claims 파싱 오류: {}", e.getMessage());
       throw new IllegalArgumentException("Invalid JWT token", e);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
   jwt:
     header: authorization
     secret: ${SECRET_KEY}
-    access-token-validity-in-seconds: 90
+    access-token-validity-in-seconds: 30
     refresh-token-validity-in-seconds: 604800
 
   security:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
   jwt:
     header: authorization
     secret: ${SECRET_KEY}
-    access-token-validity-in-seconds: 3600
+    access-token-validity-in-seconds: 90
     refresh-token-validity-in-seconds: 604800
 
   security:


### PR DESCRIPTION
## #️⃣연관된 이슈

> #160

## 📝작업 내용

1. JwtFilter 내에서 액세스 토큰 만료 여부 감지
2. ExpiredJwtException 호출
3. TokenService에서 액세스 토큰 재발급 및 RefreshTokenRotate
4. 헤더에서 Authorization: 새로운 액세스 토큰, X-Access-Token-Refreshed:true로 반환

### 스크린샷 (선택)

2025-09-09 18:03:28 - ✅ AT, RT 재발급 : XXX1@naver.com 
2025-09-09 18:04:35 - ✅ AT, RT 재발급 : XXX1@naver.com

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?