### PR TITLE
[FIX] FCM 중복 발송 방지 및 활성 상태 관리 개선

### DIFF
--- a/src/main/java/com/project/catxi/chat/config/StompEventListener.java
+++ b/src/main/java/com/project/catxi/chat/config/StompEventListener.java
@@ -1,32 +1,110 @@
 package com.project.catxi.chat.config;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
+import com.project.catxi.fcm.service.FcmActiveStatusService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class StompEventListener {
 	private final Set<String> sessions = ConcurrentHashMap.newKeySet();
+	private final Map<String, String> sessionUserMap = new ConcurrentHashMap<>(); // sessionId -> email
+	private final Map<String, Long> sessionRoomMap = new ConcurrentHashMap<>(); // sessionId -> roomId
+	private final FcmActiveStatusService fcmActiveStatusService;
 
 	@EventListener
 	public void connectHandle(SessionConnectEvent event){
 		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
-		sessions.add(accessor.getSessionId());
-		System.out.println("connect session Id" + accessor.getSessionId());
+		String sessionId = accessor.getSessionId();
+		sessions.add(sessionId);
+		
+		// 사용자 정보 저장 (Principal에서 이메일 추출)
+		if (accessor.getUser() != null) {
+			String email = accessor.getUser().getName();
+			sessionUserMap.put(sessionId, email);
+			log.debug("WebSocket 연결 - SessionId: {}, Email: {}", sessionId, email);
+		}
+		
+		System.out.println("connect session Id" + sessionId);
 		System.out.println("total session : "+sessions.size());
 	}
 
 	@EventListener
 	public void disconnectHandle(SessionDisconnectEvent event){
 		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
-		sessions.remove(accessor.getSessionId());
-		System.out.println("disconnect session Id" + accessor.getSessionId());
+		String sessionId = accessor.getSessionId();
+		
+		// 활성 상태 비활성화
+		String email = sessionUserMap.get(sessionId);
+		Long roomId = sessionRoomMap.get(sessionId);
+		
+		if (email != null && roomId != null) {
+			fcmActiveStatusService.updateUserActiveStatus(email, roomId, false);
+			log.debug("WebSocket 해제 시 FCM 활성 상태 비활성화 - Email: {}, RoomId: {}", email, roomId);
+		}
+		
+		// 세션 정보 정리
+		sessions.remove(sessionId);
+		sessionUserMap.remove(sessionId);
+		sessionRoomMap.remove(sessionId);
+		
+		System.out.println("disconnect session Id" + sessionId);
 		System.out.println("total session : "+sessions.size());
+	}
+	
+	@EventListener
+	public void subscribeHandle(SessionSubscribeEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = accessor.getSessionId();
+		String destination = accessor.getDestination();
+		
+		// 채팅방 구독 시 활성 상태 설정
+		if (destination != null && destination.startsWith("/topic/chat/")) {
+			try {
+				String roomIdStr = destination.substring("/topic/chat/".length());
+				Long roomId = Long.parseLong(roomIdStr);
+				String email = sessionUserMap.get(sessionId);
+				
+				if (email != null) {
+					sessionRoomMap.put(sessionId, roomId);
+					fcmActiveStatusService.updateUserActiveStatus(email, roomId, true);
+					log.debug("채팅방 구독 시 FCM 활성 상태 활성화 - Email: {}, RoomId: {}", email, roomId);
+				}
+			} catch (NumberFormatException e) {
+				log.warn("채팅방 ID 파싱 실패 - Destination: {}", destination);
+			}
+		}
+	}
+	
+	@EventListener
+	public void unsubscribeHandle(SessionUnsubscribeEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = accessor.getSessionId();
+		
+		// 구독 해제 시 활성 상태 비활성화
+		String email = sessionUserMap.get(sessionId);
+		Long roomId = sessionRoomMap.get(sessionId);
+		
+		if (email != null && roomId != null) {
+			fcmActiveStatusService.updateUserActiveStatus(email, roomId, false);
+			sessionRoomMap.remove(sessionId);
+			log.debug("구독 해제 시 FCM 활성 상태 비활성화 - Email: {}, RoomId: {}", email, roomId);
+		}
 	}
 }
 

--- a/src/main/java/com/project/catxi/fcm/service/FcmActiveStatusService.java
+++ b/src/main/java/com/project/catxi/fcm/service/FcmActiveStatusService.java
@@ -11,6 +11,7 @@ import com.project.catxi.common.api.exception.CatxiException;
 import com.project.catxi.member.domain.Member;
 import com.project.catxi.member.repository.MemberRepository;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -23,8 +24,10 @@ public class FcmActiveStatusService {
     
     private static final String ACTIVE_STATUS_KEY_PREFIX = "chat:active:room:%d:user:%d";
     private static final String MEMBER_CACHE_KEY_PREFIX = "member:email:%s";
+    private static final String ACTIVE_STATUS_LOCK_PREFIX = "chat:active:lock:room:%d:user:%d";
     private static final int ACTIVE_STATUS_TTL_MINUTES = 5; // 5분 TTL
     private static final int MEMBER_CACHE_TTL_MINUTES = 30; // 멤버 캐시 30분 TTL
+    private static final int LOCK_TTL_SECONDS = 10; // 락 TTL 10초
 
     /**
      * 사용자 활성 상태 업데이트
@@ -37,15 +40,29 @@ public class FcmActiveStatusService {
         try {
             Long memberId = getMemberIdFromCacheOrDb(email);
             String key = String.format(ACTIVE_STATUS_KEY_PREFIX, roomId, memberId);
-
-            if (isActive) {
-                // 활성 상태로 설정 (TTL 5분)
-                redisTemplate.opsForValue().set(key, "true", ACTIVE_STATUS_TTL_MINUTES, TimeUnit.MINUTES);
-                log.debug("사용자 활성 상태 설정 - MemberId: {}, RoomId: {}", memberId, roomId);
+            String lockKey = String.format(ACTIVE_STATUS_LOCK_PREFIX, roomId, memberId);
+            
+            // 분산 락을 사용한 동시성 제어
+            Boolean lockAcquired = redisTemplate.opsForValue()
+                .setIfAbsent(lockKey, "locked", Duration.ofSeconds(LOCK_TTL_SECONDS));
+                
+            if (Boolean.TRUE.equals(lockAcquired)) {
+                try {
+                    if (isActive) {
+                        // 활성 상태로 설정 (TTL 5분)
+                        redisTemplate.opsForValue().set(key, "true", ACTIVE_STATUS_TTL_MINUTES, TimeUnit.MINUTES);
+                        log.debug("사용자 활성 상태 설정 - MemberId: {}, RoomId: {}", memberId, roomId);
+                    } else {
+                        // 비활성 상태로 설정 (키 삭제)
+                        redisTemplate.delete(key);
+                        log.debug("사용자 비활성 상태 설정 - MemberId: {}, RoomId: {}", memberId, roomId);
+                    }
+                } finally {
+                    // 락 해제
+                    redisTemplate.delete(lockKey);
+                }
             } else {
-                // 비활성 상태로 설정 (키 삭제)
-                redisTemplate.delete(key);
-                log.debug("사용자 비활성 상태 설정 - MemberId: {}, RoomId: {}", memberId, roomId);
+                log.debug("사용자 활성 상태 업데이트 락 획득 실패 - MemberId: {}, RoomId: {}", memberId, roomId);
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #162 

## 📝작업 내용

- Redis PubSub 중복 처리 방지 로직 추가 (EventId 기반)
- FCM 활성 상태 분산 락 적용으로 동시성 제어 강화
- WebSocket 세션 기반 자동 FCM 활성 상태 관리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?