### PR TITLE
[FIX] 로드밸런싱 환경에서 FCM 중복 발송 방지

### DIFF
--- a/src/main/java/com/project/catxi/common/service/RedisDistributedLockService.java
+++ b/src/main/java/com/project/catxi/common/service/RedisDistributedLockService.java
@@ -1,0 +1,147 @@
+package com.project.catxi.common.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisDistributedLockService {
+    
+    private final @Qualifier("chatPubSub") StringRedisTemplate redisTemplate;
+    
+    private static final String LOCK_PREFIX = "fcm:lock:";
+    private static final String UNLOCK_SCRIPT = 
+        "if redis.call('get', KEYS[1]) == ARGV[1] then " +
+        "    return redis.call('del', KEYS[1]) " +
+        "else " +
+        "    return 0 " +
+        "end";
+    
+    /**
+     * 분산락 획득 시도
+     * @param lockKey 락 키
+     * @param ttlSeconds 락 만료 시간 (초)
+     * @return LockResult (성공 여부와 락 식별자)
+     */
+    public LockResult tryLock(String lockKey, int ttlSeconds) {
+        try {
+            String fullLockKey = LOCK_PREFIX + lockKey;
+            String lockValue = generateLockValue();
+            
+            Boolean acquired = redisTemplate.opsForValue()
+                .setIfAbsent(fullLockKey, lockValue, Duration.ofSeconds(ttlSeconds));
+            
+            if (Boolean.TRUE.equals(acquired)) {
+                log.debug("분산락 획득 성공 - Key: {}, Value: {}, TTL: {}s", lockKey, lockValue, ttlSeconds);
+                return LockResult.success(lockValue);
+            } else {
+                log.debug("분산락 획득 실패 - Key: {} (이미 다른 서버에서 처리 중)", lockKey);
+                return LockResult.failed();
+            }
+            
+        } catch (Exception e) {
+            log.error("분산락 획득 중 오류 - Key: {}, Error: {}", lockKey, e.getMessage(), e);
+            return LockResult.failed();
+        }
+    }
+    
+    /**
+     * 분산락 해제 (원자적 연산)
+     * @param lockKey 락 키
+     * @param lockValue 락 식별자
+     * @return 해제 성공 여부
+     */
+    public boolean releaseLock(String lockKey, String lockValue) {
+        try {
+            String fullLockKey = LOCK_PREFIX + lockKey;
+            
+            DefaultRedisScript<Long> redisScript = new DefaultRedisScript<>();
+            redisScript.setScriptText(UNLOCK_SCRIPT);
+            redisScript.setResultType(Long.class);
+            
+            Long result = redisTemplate.execute(redisScript, 
+                Collections.singletonList(fullLockKey), lockValue);
+            
+            boolean released = result != null && result.equals(1L);
+            
+            if (released) {
+                log.debug("분산락 해제 성공 - Key: {}, Value: {}", lockKey, lockValue);
+            } else {
+                log.debug("분산락 해제 실패 - Key: {} (이미 만료되었거나 다른 락)", lockKey);
+            }
+            
+            return released;
+            
+        } catch (Exception e) {
+            log.error("분산락 해제 중 오류 - Key: {}, Error: {}", lockKey, e.getMessage(), e);
+            return false;
+        }
+    }
+    
+    /**
+     * 락과 함께 작업 실행 (try-with-resources 패턴)
+     * @param lockKey 락 키
+     * @param ttlSeconds 락 만료 시간
+     * @param task 실행할 작업
+     * @return 작업 실행 성공 여부
+     */
+    public boolean executeWithLock(String lockKey, int ttlSeconds, Runnable task) {
+        LockResult lockResult = tryLock(lockKey, ttlSeconds);
+        
+        if (!lockResult.isSuccess()) {
+            return false;
+        }
+        
+        try {
+            task.run();
+            return true;
+        } catch (Exception e) {
+            log.error("락 보호 작업 실행 중 오류 - Key: {}, Error: {}", lockKey, e.getMessage(), e);
+            throw e;
+        } finally {
+            releaseLock(lockKey, lockResult.getLockValue());
+        }
+    }
+    
+    private String generateLockValue() {
+        return Thread.currentThread().getName() + ":" + UUID.randomUUID().toString();
+    }
+    
+    /**
+     * 락 획득 결과 클래스
+     */
+    public static class LockResult {
+        private final boolean success;
+        private final String lockValue;
+        
+        private LockResult(boolean success, String lockValue) {
+            this.success = success;
+            this.lockValue = lockValue;
+        }
+        
+        public static LockResult success(String lockValue) {
+            return new LockResult(true, lockValue);
+        }
+        
+        public static LockResult failed() {
+            return new LockResult(false, null);
+        }
+        
+        public boolean isSuccess() {
+            return success;
+        }
+        
+        public String getLockValue() {
+            return lockValue;
+        }
+    }
+}

--- a/src/main/java/com/project/catxi/fcm/service/FcmEventPublisher.java
+++ b/src/main/java/com/project/catxi/fcm/service/FcmEventPublisher.java
@@ -3,6 +3,8 @@ package com.project.catxi.fcm.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.catxi.fcm.dto.FcmNotificationEvent;
+import com.project.catxi.fcm.util.FcmBusinessKeyGenerator;
+import com.project.catxi.common.service.RedisDistributedLockService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -18,21 +20,45 @@ public class FcmEventPublisher {
     
     private final @Qualifier("chatPubSub") StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
+    private final RedisDistributedLockService distributedLockService;
+    private final FcmBusinessKeyGenerator businessKeyGenerator;
     
     /**
-     * FCM 알림 이벤트를 Redis에 발행
+     * FCM 알림 이벤트를 Redis에 발행 (분산락으로 중복 발행 방지)
      */
     public void publishFcmEvent(FcmNotificationEvent event) {
         try {
-            String eventJson = objectMapper.writeValueAsString(event);
-            redisTemplate.convertAndSend(FCM_CHANNEL, eventJson);
+            // 비즈니스 로직 기반 분산락 키 생성
+            String businessLockKey = businessKeyGenerator.generateBusinessKey(event);
+            String publishLockKey = "publish:" + businessLockKey;
             
-            log.info("FCM 이벤트 발행 완료 - EventId: {}, Type: {}, Targets: {}", 
-                    event.eventId(), event.type(), event.targetMemberIds().size());
+            log.info("FCM 이벤트 발행 시도 - EventId: {}, Type: {}, BusinessKey: {}, Targets: {}", 
+                    event.eventId(), event.type(), businessLockKey, event.targetMemberIds().size());
+            
+            // 분산락을 사용하여 중복 발행 방지 (10초 TTL)
+            boolean published = distributedLockService.executeWithLock(
+                publishLockKey,
+                10, // 10초 락 TTL
+                () -> {
+                    try {
+                        String eventJson = objectMapper.writeValueAsString(event);
+                        redisTemplate.convertAndSend(FCM_CHANNEL, eventJson);
+                        
+                        log.info("FCM 이벤트 발행 완료 - EventId: {}, BusinessKey: {}, Type: {}", 
+                                event.eventId(), businessLockKey, event.type());
+                    } catch (JsonProcessingException e) {
+                        log.error("FCM 이벤트 직렬화 실패 - EventId: {}, Error: {}", 
+                                event.eventId(), e.getMessage(), e);
+                        throw new RuntimeException("FCM 이벤트 직렬화 실패", e);
+                    }
+                }
+            );
+            
+            if (!published) {
+                log.debug("FCM 이벤트 중복 발행 방지 (분산락) - EventId: {}, BusinessKey: {}", 
+                        event.eventId(), businessLockKey);
+            }
                     
-        } catch (JsonProcessingException e) {
-            log.error("FCM 이벤트 직렬화 실패 - EventId: {}, Error: {}", 
-                    event.eventId(), e.getMessage(), e);
         } catch (Exception e) {
             log.error("FCM 이벤트 발행 실패 - EventId: {}, Error: {}", 
                     event.eventId(), e.getMessage(), e);

--- a/src/main/java/com/project/catxi/fcm/util/FcmBusinessKeyGenerator.java
+++ b/src/main/java/com/project/catxi/fcm/util/FcmBusinessKeyGenerator.java
@@ -1,0 +1,110 @@
+package com.project.catxi.fcm.util;
+
+import com.project.catxi.fcm.dto.FcmNotificationEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+public class FcmBusinessKeyGenerator {
+    
+    /**
+     * FCM 이벤트의 비즈니스 로직 기반 고유 키 생성
+     */
+    public String generateBusinessKey(FcmNotificationEvent event) {
+        try {
+            switch (event.type()) {
+                case CHAT_MESSAGE:
+                    return generateChatMessageKey(event);
+                case READY_REQUEST:
+                    return generateReadyRequestKey(event);
+                case SYSTEM_NOTIFICATION:
+                    return generateSystemNotificationKey(event);
+                default:
+                    log.warn("알 수 없는 FCM 이벤트 타입 - Type: {}, EventId: {}", 
+                            event.type(), event.eventId());
+                    return "unknown:" + event.eventId();
+            }
+        } catch (Exception e) {
+            log.error("FCM 비즈니스 키 생성 실패 - EventId: {}, Error: {}", 
+                    event.eventId(), e.getMessage(), e);
+            return "error:" + event.eventId();
+        }
+    }
+    
+    /**
+     * 채팅 메시지 FCM 키 생성
+     * 형식: chat:{roomId}:{targetMemberId}:{timeWindow}:{messageHash}
+     */
+    private String generateChatMessageKey(FcmNotificationEvent event) {
+        String roomId = event.data().get("roomId");
+        Long targetMemberId = event.targetMemberIds().get(0);
+        
+        // 1분 단위 시간 윈도우 (같은 메시지가 1분 내 중복 발송 방지)
+        long timeWindow = System.currentTimeMillis() / 60000;
+        
+        // 메시지 내용 기반 해시 (같은 내용 중복 방지)
+        String messageHash = generateHash(event.body());
+        
+        return String.format("chat:%s:%d:%d:%s", roomId, targetMemberId, timeWindow, messageHash);
+    }
+    
+    /**
+     * 준비 요청 FCM 키 생성
+     * 형식: ready:{roomId}:{timeWindow}
+     */
+    private String generateReadyRequestKey(FcmNotificationEvent event) {
+        String roomId = event.data().get("roomId");
+        
+        // 30초 단위 시간 윈도우 (준비요청은 30초 내 중복 발송 방지)
+        long timeWindow = System.currentTimeMillis() / 30000;
+        
+        return String.format("ready:%s:%d", roomId, timeWindow);
+    }
+    
+    /**
+     * 시스템 알림 FCM 키 생성
+     * 형식: system:{targetMemberId}:{timeWindow}:{contentHash}
+     */
+    private String generateSystemNotificationKey(FcmNotificationEvent event) {
+        Long targetMemberId = event.targetMemberIds().get(0);
+        
+        // 5분 단위 시간 윈도우
+        long timeWindow = System.currentTimeMillis() / 300000;
+        
+        String contentHash = generateHash(event.title() + ":" + event.body());
+        
+        return String.format("system:%d:%d:%s", targetMemberId, timeWindow, contentHash);
+    }
+    
+    /**
+     * 문자열의 SHA-256 해시 생성 (앞 8자리만 사용)
+     */
+    private String generateHash(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            
+            // 해시의 앞 8자리만 사용 (키 길이 단축)
+            StringBuilder hexString = new StringBuilder();
+            for (int i = 0; i < Math.min(4, hash.length); i++) {
+                String hex = Integer.toHexString(0xff & hash[i]);
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.toString();
+            
+        } catch (NoSuchAlgorithmException e) {
+            log.error("SHA-256 해시 생성 실패: {}", e.getMessage());
+            // 해시 생성 실패 시 입력 문자열의 해시코드 사용
+            return String.valueOf(Math.abs(input.hashCode()));
+        }
+    }
+    
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #164 

## 📝작업 내용

> 🔒 분산락 기반 FCM 중복 발송 방지 구현

  로드밸런싱 환경에서 발생하는 FCM 중복 발송 문제를 Redis 분산락으로 해결했습니다. 기존 EventId 기반 중복 방지를 비즈니스 로직 기반 키(roomId + memberId + timeWindow + messageHash)로 변경하여 서로 다른 서버에서 같은 내용의 알림이 발생해도 한 번만 처리되도록 보장합니다. 발행(Publisher) 단계와 소비(Consumer) 단계 모두에서 분산락을 적용해 이중 보호막을 구축했으며, TTL을 통한 자동 락 해제로 데드락을 방지합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?