### PR TITLE
[FEAT] FCM 토큰 삭제 구현 및 중복 알림 해결

### DIFF
--- a/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
+++ b/src/main/java/com/project/catxi/chat/service/ChatMessageService.java
@@ -73,18 +73,19 @@ public class ChatMessageService {
 			// 방에 참여한 다른 사용자들 조회 (발송자 제외)
 			List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(room);
 			
-			participants.stream()
-				.filter(participant -> participant.getMember() != null)
-				.filter(participant -> !participant.getMember().getId().equals(sender.getId()))
-				.filter(participant -> !fcmActiveStatusService.isUserActiveInRoom(
-					participant.getMember().getId(), room.getRoomId()))
-				.forEach(participant -> {
-					fcmEventPublisher.publishChatNotification(
-						participant.getMember().getId(),
-						sender.getNickname() != null ? sender.getNickname() : sender.getMembername(),
-						message
-					);
-				});
+            participants.stream()
+                .filter(participant -> participant.getMember() != null)
+                .filter(participant -> !participant.getMember().getId().equals(sender.getId()))
+                .filter(participant -> !fcmActiveStatusService.isUserActiveInRoom(
+                    participant.getMember().getId(), room.getRoomId()))
+                .forEach(participant -> {
+                    fcmEventPublisher.publishChatNotification(
+                        participant.getMember().getId(),
+                        room.getRoomId(), // roomId 추가
+                        sender.getNickname() != null ? sender.getNickname() : sender.getMembername(),
+                        message
+                    );
+                });
 				
 		} catch (Exception e) {
 			// FCM 알림 실패가 채팅 저장을 방해하지 않도록 예외 처리

--- a/src/main/java/com/project/catxi/common/api/error/FcmErrorCode.java
+++ b/src/main/java/com/project/catxi/common/api/error/FcmErrorCode.java
@@ -12,7 +12,8 @@ public enum FcmErrorCode implements ErrorCode {
     FCM_TOKEN_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FCM401", "FCM 토큰 업데이트에 실패했습니다."),
     FCM_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "FCM402", "FCM 서비스를 사용할 수 없습니다."),
     FCM_NOTIFICATION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FCM403", "FCM 알림 발송에 실패했습니다."),
-    INVALID_FCM_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "FCM404", "올바르지 않은 FCM 토큰 형식입니다.");
+    INVALID_FCM_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "FCM404", "올바르지 않은 FCM 토큰 형식입니다."),
+    FCM_TOKEN_DELETION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FCM405", "FCM 토큰 삭제에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/project/catxi/fcm/controller/FcmController.java
+++ b/src/main/java/com/project/catxi/fcm/controller/FcmController.java
@@ -50,4 +50,17 @@ public class FcmController {
         return ResponseEntity.ok(ApiResponse.successWithNoData());
     }
 
+    @DeleteMapping("/token")
+    public ResponseEntity<ApiResponse<Void>> deleteFcmToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        
+        String email = userDetails.getUsername();
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CatxiException(MemberErrorCode.MEMBER_NOT_FOUND));
+        
+        fcmTokenService.deleteFcmToken(member);
+        
+        return ResponseEntity.ok(ApiResponse.successWithNoData());
+    }
+
 }

--- a/src/main/java/com/project/catxi/fcm/dto/FcmNotificationEvent.java
+++ b/src/main/java/com/project/catxi/fcm/dto/FcmNotificationEvent.java
@@ -21,18 +21,17 @@ public record FcmNotificationEvent(
 ) {
     
     // 단일 사용자용 정적 팩토리 메서드
-    public static FcmNotificationEvent createChatMessage(Long targetMemberId, String senderNickname, String message) {
+    public static FcmNotificationEvent createChatMessage(Long targetMemberId, Long roomId, String senderNickname, String message) {
         String eventId = UUID.randomUUID().toString();
-        String businessKey = String.format("chat:%s:%s", targetMemberId, System.currentTimeMillis());
         
         return new FcmNotificationEvent(
                 eventId,
-                businessKey,
+                null, // businessKey는 Publisher에서 생성
                 NotificationType.CHAT_MESSAGE,
                 List.of(targetMemberId),
                 "새로운 채팅 메시지",
                 String.format("%s: %s", senderNickname, message),
-                Map.of("type", "CHAT"),
+                Map.of("type", "CHAT", "roomId", String.valueOf(roomId)),
                 LocalDateTime.now(),
                 0
         );
@@ -41,11 +40,10 @@ public record FcmNotificationEvent(
     // 다중 사용자용 정적 팩토리 메서드  
     public static FcmNotificationEvent createReadyRequest(List<Long> targetMemberIds, Long roomId) {
         String eventId = UUID.randomUUID().toString();
-        String businessKey = String.format("ready:%s:%s", roomId, System.currentTimeMillis());
         
         return new FcmNotificationEvent(
                 eventId,
-                businessKey,
+                null, // businessKey는 Publisher에서 생성
                 NotificationType.READY_REQUEST,
                 targetMemberIds,
                 "준비 요청",
@@ -53,6 +51,20 @@ public record FcmNotificationEvent(
                 Map.of("type", "READY_REQUEST", "roomId", roomId.toString()),
                 LocalDateTime.now(),
                 0
+        );
+    }
+
+    public FcmNotificationEvent withBusinessKey(String businessKey) {
+        return new FcmNotificationEvent(
+            this.eventId,
+            businessKey,
+            this.type,
+            this.targetMemberIds,
+            this.title,
+            this.body,
+            this.data,
+            this.createdAt,
+            this.retryCount
         );
     }
     

--- a/src/main/java/com/project/catxi/fcm/service/FcmEventPublisher.java
+++ b/src/main/java/com/project/catxi/fcm/service/FcmEventPublisher.java
@@ -3,6 +3,7 @@ package com.project.catxi.fcm.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.catxi.fcm.dto.FcmNotificationEvent;
+import com.project.catxi.fcm.util.FcmBusinessKeyGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -18,20 +19,25 @@ public class FcmEventPublisher {
     
     private final @Qualifier("chatPubSub") StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
+    private final FcmBusinessKeyGenerator fcmBusinessKeyGenerator;
     
     /**
      * FCM 알림 이벤트를 Redis PubSub에 발행 (분산락으로 중복 처리 방지)
      */
     public void publishFcmEvent(FcmNotificationEvent event) {
         try {
+            // BusinessKey 생성 및 이벤트 업데이트
+            String businessKey = fcmBusinessKeyGenerator.generateBusinessKey(event);
+            FcmNotificationEvent eventWithKey = event.withBusinessKey(businessKey);
+
             log.info("FCM 이벤트 발행 시도 - EventId: {}, Type: {}, BusinessKey: {}, Targets: {}", 
-                    event.eventId(), event.type(), event.businessKey(), event.targetMemberIds().size());
+                    eventWithKey.eventId(), eventWithKey.type(), eventWithKey.businessKey(), eventWithKey.targetMemberIds().size());
             
-            String eventJson = objectMapper.writeValueAsString(event);
+            String eventJson = objectMapper.writeValueAsString(eventWithKey);
             redisTemplate.convertAndSend(FCM_CHANNEL, eventJson);
             
             log.info("FCM 이벤트 발행 완료 - EventId: {}, BusinessKey: {}, Type: {}", 
-                    event.eventId(), event.businessKey(), event.type());
+                    eventWithKey.eventId(), eventWithKey.businessKey(), eventWithKey.type());
                     
         } catch (JsonProcessingException e) {
             log.error("FCM 이벤트 직렬화 실패 - EventId: {}, Error: {}", 
@@ -45,9 +51,9 @@ public class FcmEventPublisher {
     /**
      * 채팅 메시지 알림 이벤트 발행
      */
-    public void publishChatNotification(Long targetMemberId, String senderNickname, String message) {
+    public void publishChatNotification(Long targetMemberId, Long roomId, String senderNickname, String message) {
         FcmNotificationEvent event = FcmNotificationEvent.createChatMessage(
-                targetMemberId, senderNickname, message);
+                targetMemberId, roomId, senderNickname, message);
         publishFcmEvent(event);
     }
     

--- a/src/main/java/com/project/catxi/fcm/service/FcmTokenService.java
+++ b/src/main/java/com/project/catxi/fcm/service/FcmTokenService.java
@@ -59,6 +59,24 @@ public class FcmTokenService {
         }
     }
 
+    @Transactional
+    public void deleteFcmToken(Member member) {
+        try {
+            if (member.getFcmToken() == null) {
+                log.info("삭제할 FCM 토큰이 없음 - Member ID: {}", member.getId());
+                return; // 이미 토큰이 없는 경우, 바로 종료
+            }
+
+            member.updateFcmToken(null);
+            memberRepository.save(member);
+            log.info("FCM 토큰 삭제 완료 - Member ID: {}", member.getId());
+
+        } catch (Exception e) {
+            log.error("FCM 토큰 삭제 실패 - Member ID: {}, Error: {}", member.getId(), e.getMessage(), e);
+            throw new CatxiException(FcmErrorCode.FCM_TOKEN_DELETION_FAILED);
+        }
+    }
+
     public List<String> getActiveTokens(Member member) {
         try {
             return member.getFcmToken() != null 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #166 

## 📝작업 내용

   1. 알림 대상 필터링 (`ChatMessageService`):
   2. FCM 이벤트 생성 (`FcmEventPublisher`):
   3. 고유 식별 키(`businessKey`) 생성 (`FcmEventPublisher`):
   4. Redis에 이벤트 발행 (`FcmEventPublisher`):
   1. 모든 서버가 이벤트 수신: 로드밸런싱 된 서버 1과 서버 2가 동시에 Redis로부터 동일한 FCM 이벤트를 수신합니다.
   2. 1차 중복 방어: 디듀플리케이션(Deduplication) 키:
   3. 2차 중복 방어: 분산 락 (Race Condition 방지):
   4. FCM 알림 발송:
  이러한 과정을 통해, 채팅방에 접속 중인 사용자는 실시간으로 메시지를 받고, 접속 중이지 않은 사용자는 중복 없이 정확하게 한 번의 푸시 알림을 받게 됩니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?