### PR TITLE
[FIX] Node Exporter 인코딩 에러 해결

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -99,8 +99,14 @@ services:
       - '--path.sysfs=/host/sys'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
       - '--no-collector.ipvs'
-      - '--web.max-requests=100'
-      - '--log.level=info'
+      - '--no-collector.netstat'
+      - '--no-collector.sockstat'
+      - '--no-collector.softnet'
+      - '--no-collector.netdev'
+      - '--no-collector.netclass'
+      - '--web.max-requests=50'
+      - '--web.max-connections=20'
+      - '--log.level=warn'
     deploy:
       resources:
         limits:

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,6 +1,7 @@
 global:
-  scrape_interval: 15s
-  scrape_timeout: 12s
+  scrape_interval: 30s
+  evaluation_interval: 30s
+  scrape_timeout: 15s
 
 alerting:
   alertmanagers:
@@ -15,14 +16,11 @@ scrape_configs:
   - job_name: 'node-exporter'
     static_configs:
       - targets: ['node-exporter:9100']
-    scrape_interval: 15s
-    scrape_timeout: 12s
-
-  - job_name: 'node-exporter'
-    static_configs:
-      - targets: ['node-exporter:9100']
-    scrape_interval: 30s
+    scrape_interval: 45s
+    scrape_timeout: 10s
     metrics_path: /metrics
+    params:
+      'timeout': ['8s']
 
   - job_name: 'pushgateway'
     static_configs:


### PR DESCRIPTION
## #️⃣연관된 이슈

> #175 

## 📝작업 내용

![그라파나 Explore 오류 그래프](https://github.com/user-attachments/assets/86f6cdff-b1e4-46e3-8ccf-38779b7c99d1)
![컨테이너 실제 오류 로그](https://github.com/user-attachments/assets/f3d63ded-d2a2-4a1e-a377-a3316972be29)
기존 문제점

  - Node Exporter 인코딩 에러 430,716회 발생 - 메트릭 HTTP 응답 중 연결 끊어짐
  - Prometheus 중복 스크래핑 - 동일한 target에 대해 2개 job 설정
  - 과도한 동시 연결 - 짧은 간격(15s) 스크래핑으로 연결 충돌
  - 불필요한 네트워크 메트릭 수집 - 메트릭 크기 증가로 인코딩 부하

해결 작업

  1. Prometheus 설정 최적화
    - 스크래핑 간격: 15s → 45s (연결 충돌 방지)
    - 타임아웃: 12s → 10s (빠른 연결 해제)
    - 중복 job 제거
  2. Node Exporter 경량화
    - 네트워크 관련 컬렉터 5개 비활성화 (netstat, sockstat, softnet, netdev, netclass)
    - 동시 연결 제한: 100 → 50, 최대 연결: 20개


### 스크린샷 
<img width="1416" height="782" alt="image" src="https://github.com/user-attachments/assets/ad8e0665-34ea-4fa1-8578-8101964d1493" />
위 사진의 그래프와 동일하게 해결 방안이 적용된 17:20 이후로는 broken pipe 현상이 발생하지 않는 것을 볼 수 있습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?